### PR TITLE
objWriterの変換結果の3Dモデルが極端に細長くなる問題を修正しました。

### DIFF
--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Interop/NativeMethods.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Interop/NativeMethods.cs
@@ -76,9 +76,9 @@ namespace PLATEAU.Interop
         public MeshGranularity MeshGranularity;
         public uint MinLOD;
         public uint MaxLOD;
-        public bool ExportLowerLOD;
-        public bool ExportAppearance;
-        public bool ConvertLatLon;
+        [MarshalAs(UnmanagedType.U1)] public bool ExportLowerLOD;
+        [MarshalAs(UnmanagedType.U1)] public bool ExportAppearance;
+        [MarshalAs(UnmanagedType.U1)] public bool ConvertLatLon;
     }
 
     public enum APIResult


### PR DESCRIPTION
## 実装内容
MeshConvertOptionsのマーシャリングを修正したら直りました。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
Unityでの変換結果です。
![image](https://user-images.githubusercontent.com/1321932/175561541-60bed3cd-0e23-443f-a8e9-9003b37d12c8.png)
