### PR TITLE
Unityの座標系は正しくはEUNだったので修正しました。ReferencePointが変換後の座標系で動作するようにしました。

### DIFF
--- a/include/plateau/geometry/geo_coordinate.h
+++ b/include/plateau/geometry/geo_coordinate.h
@@ -45,10 +45,11 @@ namespace plateau::geometry {
     enum class CoordinateSystem {
         //! PLATEAUでの座標系
         ENU,
-        //! Unityでの座標系
         WUN,
         //! Unreal Engineでの座標系
-        NWU
+        NWU,
+        //! Unityでの座標系
+        EUN
     };
 
     /**

--- a/src/io/gltf_writer.cpp
+++ b/src/io/gltf_writer.cpp
@@ -83,6 +83,11 @@ namespace {
             converted_position.y = -position.x;
             converted_position.z = position.z;
             return converted_position;
+        case CoordinateSystem::EUN:
+            converted_position.x = position.x;
+            converted_position.y = position.z;
+            converted_position.z = position.y;
+            return converted_position;
         default:
             throw std::out_of_range("Invalid argument");
         }

--- a/src/io/obj_writer.cpp
+++ b/src/io/obj_writer.cpp
@@ -91,6 +91,11 @@ namespace {
                 converted_position.y = -position.x;
                 converted_position.z = position.z;
                 return converted_position;
+            case CoordinateSystem::EUN:
+                converted_position.x = position.x;
+                converted_position.y = position.z;
+                converted_position.z = position.y;
+                return converted_position;
             default:
                 throw std::out_of_range("Invalid argument");
         }

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Geom/GeoReferenceTests.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Geom/GeoReferenceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PLATEAU.Geom;
 using PLATEAU.Interop;
@@ -92,6 +93,7 @@ namespace PLATEAU.Test.Geom
             CheckProjectUnproject(new PlateauVector3d(0, 0, 0), 1f, CoordinateSystem.ENU, 9);
             CheckProjectUnproject(new PlateauVector3d(10, 10, 10), 2f, CoordinateSystem.WUN, 9);
             CheckProjectUnproject(new PlateauVector3d(100, 100, 100), 3f, CoordinateSystem.NWU, 9);
+            CheckProjectUnproject(new PlateauVector3d(-100, -100, -100), 4f, CoordinateSystem.EUN, 9);
         }
 
         private static void CheckProjectUnproject(PlateauVector3d reference_point, float unit_scale, CoordinateSystem coordinate_system, int zone_id)
@@ -101,6 +103,7 @@ namespace PLATEAU.Test.Geom
             var longitude = 139.74256342432295;
             var xyz = geoReference.Project(new GeoCoordinate(latitude, longitude, 0.0));
             var lat_lon = geoReference.Unproject(xyz);
+            Console.WriteLine($"lat diff = {lat_lon.Latitude - latitude}, lon diff = {lat_lon.Longitude - longitude}");
             Assert.IsTrue(Math.Abs(lat_lon.Latitude - latitude) < 0.00000001);//およそ1mm相当の誤差以内か
             Assert.IsTrue(Math.Abs(lat_lon.Longitude - longitude) < 0.00000001);//およそ1mm相当の誤差以内か
         }

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/IO/MeshConvertOptions.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/IO/MeshConvertOptions.cs
@@ -15,14 +15,15 @@ namespace PLATEAU.IO
         /// PLATEAUでの座標系
         /// </summary>
         ENU,
-        /// <summary>
-        /// Unityでの座標系
-        /// </summary>
         WUN,
         /// <summary>
         /// Unreal Engineでの座標系
         /// </summary>
-        NWU
+        NWU,
+        /// <summary>
+        /// Unityでの座標系
+        /// </summary>
+        EUN
     }
 
     /// <summary>


### PR DESCRIPTION
## 実装内容
- CoordinateSystemでUnityの座標系は今までWUNということになっていましたが、正しくはEUNだったので CoordinateSystem::EUN とその変換処理を追加しました。
- ReferencePointが変換後の座標系で動作するようにしました。今まではUnity(EUN)から Reference Point を指定するときであっても CoordinateSystem::ENU座標系で指定する必要があって不便でしたが、UnityならUnityの座標系で Reference Point を指定できるようになりました。

## レビュー前確認項目
テストは Udx関連以外のものが通ります。

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
