### PR TITLE
AttributesMapにGetValueOrNullメソッドを追加しました

### DIFF
--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/CityGML/AttributesMapTests.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/CityGML/AttributesMapTests.cs
@@ -83,6 +83,20 @@ namespace PLATEAU.Test.CityGML
         }
 
         [TestMethod]
+        public void GetValueOrNull_Returns_Value_If_Found()
+        {
+            var val = this.attrMap.GetValueOrNull("建物ID");
+            Assert.AreEqual("13111-bldg-98", val.AsString);
+        }
+
+        [TestMethod]
+        public void GetValueOrNull_Returns_Null_If_Not_Found()
+        {
+            var val = this.attrMap.GetValueOrNull("DummyNotFound");
+            Assert.IsNull(val);
+        }
+
+        [TestMethod]
         public void ContainsKey_Returns_True_On_Found()
         {
             bool result = this.attrMap.ContainsKey("建物ID");

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/CityGML/AttributesMap.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/CityGML/AttributesMap.cs
@@ -87,7 +87,6 @@ namespace PLATEAU.CityGML
         /// <summary>
         /// 属性のキーから値を返します。
         /// <paramref name="key"/> が存在しない場合は <see cref="KeyNotFoundException"/> を投げます。
-        /// 例外を投げてほしくない場合は代わりに <see cref="TryGetValue"/> メソッドを利用してください。
         /// </summary>
         public AttributeValue this[string key]
         {
@@ -133,6 +132,16 @@ namespace PLATEAU.CityGML
 
             value = null;
             return false;
+        }
+
+        /// <summary>
+        /// <paramref name="key"/> に対応する値 <see cref="AttributeValue"/> を返します。
+        /// なければ null を返します。
+        /// </summary>
+        public AttributeValue GetValueOrNull(string key)
+        {
+            if (ContainsKey(key)) return this[key];
+            return null;
         }
 
         public IEnumerator<AttrPair> GetEnumerator()


### PR DESCRIPTION
## 実装内容
都市オブジェクトの属性値を取得するとき、  `AttributeMap.GetValueOrNull(key)` があると便利なので実装しました。
便利な点:
```cs
string str = attrMap.GetValueOrNull("キー1")?.GetValueOrNull("キー2")?.AsString ?? "";
``` 
のように `if(val==null)` を挟む代わりに `?.` で繋げることができます。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [x] 自動ビルド・テストが通っていること
- [x] Squash and Mergeが選択されていること
- [x] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
C# ユニットテストを実装済みです。
