### PR TITLE
iOS, Androidビルド自動化

### DIFF
--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: libplateau-ios-dll
-          path: ${{github.workspace}}/out/build/x64-Release/src/plateau.framework
+          path: ${{github.workspace}}/out/build/x64-Release/src/Release-iphoneos/plateau.framework
 
   # 3つ目のジョブです。
   # OSごとのアーティファクトを1つにまとめます。

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -90,7 +90,6 @@ jobs:
         compile-sdk: [33]
         build-tools: [30.0.3]
         ndk-version: [23.1.7779620]
-        root-project-path: [./AndroidNDK]
 
     steps:
       - uses: actions/checkout@v3
@@ -105,25 +104,18 @@ jobs:
         shell: bash
         run: git submodule update --init --recursive
 
-
-
-
-
-
-
-
-
       - name: setup ubuntu
         run: |
           sudo apt-get --quiet update --yes
           sudo apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
+
       - name: setup JDK 1.8
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
+
       - name: download Android SDK
-        #working-directory: ${{ matrix.root-project-path }}
         run: |
           wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip
           unzip -d android-sdk-linux android-sdk.zip
@@ -137,15 +129,13 @@ jobs:
           set +o pipefail
           yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
           set -o pipefail
+
       - name: install Android NDK
-        #working-directory: ${{ matrix.root-project-path }}
         run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" 
+
       - name: Insert NDK path
-        #working-directory: ${{ matrix.root-project-path }}
         run: |
           echo "ndk.dir=$PWD/ndk/${{ matrix.ndk-version }}" >> ./local.properties
-
-
 
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v3
@@ -160,7 +150,7 @@ jobs:
           -D ANDROID_ABI=arm64-v8a 
           -D CMAKE_MAKE_PROGRAM=ninja
           -D CMAKE_BUILD_TYPE=Release
-          -DCMAKE_TOOLCHAIN_FILE=$PWD/ndk/${{ matrix.ndk-version }}/build/cmake/android.toolchain.cmake
+          -D CMAKE_TOOLCHAIN_FILE=$PWD/ndk/${{ matrix.ndk-version }}/build/cmake/android.toolchain.cmake
 
       - name: Build by CMake
         run: cmake --build ${{github.workspace}}/out/build/x64-Release --config Release

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -5,9 +5,10 @@ name: Upload DLLs
 
 # 手動でgithubサイトのボタンを押したときか、タグを作ったときに実行します。
 on:
-  workflow_dispatch:
-  create:
-    tags: '*'
+  push:
+  #workflow_dispatch:
+  #create:
+  #  tags: '*'
 
 env:
   BUILD_TYPE: RelWithDebInfo
@@ -77,8 +78,111 @@ jobs:
           name: libplateau-${{matrix.os}}-dll
           path: ${{env.HOME}}/output/
 
+  # 2つ目のジョブ。
+  # Android用にライブラリをビルド。
+  upload_android_dlls:
 
-  # 2つ目のジョブです。
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compile-sdk: [33]
+        build-tools: [30.0.3]
+        ndk-version: [23.1.7779620]
+        cmake-version: [3.22.0]
+        root-project-path: [./AndroidNDK]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Add SSH private keys for submodule repositories
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.KEY_TO_ACCESS_FBXSDK }}
+
+      - name: checkout submodules
+        shell: bash
+        run: git submodule update --init --recursive
+
+
+
+
+
+
+
+
+
+      - name: setup ubuntu
+        run: |
+          sudo apt-get --quiet update --yes
+          sudo apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
+      - name: setup JDK 1.8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: download Android SDK
+        working-directory: ${{ matrix.root-project-path }}
+        run: |
+          wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip
+          unzip -d android-sdk-linux android-sdk.zip
+          sudo mkdir -p /root/.android
+          sudo touch /root/.android/repositories.cfg
+          echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "platforms;android-${{ matrix.compile-sdk }}" >/dev/null
+          echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "platform-tools" >/dev/null
+          echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "build-tools;${{ matrix.build-tools }}" >/dev/null
+          export ANDROID_SDK_ROOT=$PWD
+          export PATH=$PATH:$PWD/platform-tools/
+          chmod +x ./gradlew
+          set +o pipefail
+          yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
+          set -o pipefail
+      - name: install Android NDK
+        working-directory: ${{ matrix.root-project-path }}
+        run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" "cmake;${{ matrix.cmake-version }}"
+      - name: Insert NDK path
+        working-directory: ${{ matrix.root-project-path }}
+        run: |
+          echo "ndk.dir=$PWD/ndk/${{ matrix.ndk-version }}" >> ./local.properties
+
+
+
+
+
+
+
+  # 3つ目のジョブ。
+  # iOS用にライブラリをビルド。
+  upload_ios_dlls:
+
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Add SSH private keys for submodule repositories
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.KEY_TO_ACCESS_FBXSDK }}
+
+      - name: checkout submodules
+        shell: bash
+        run: git submodule update --init --recursive
+
+
+
+
+
+
+
+
+  # 4つ目のジョブです。
   # OSごとのアーティファクトを1つにまとめます。
   sum-up-dlls:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -79,10 +79,10 @@ jobs:
           path: ${{env.HOME}}/output/
 
   # 2つ目のジョブ。
-  # Android用にライブラリをビルド。
-  upload_android_dlls:
+  # AndroidとiOS用にライブラリをビルド。
+  upload_mobile_dlls:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
 
     strategy:
       fail-fast: false
@@ -105,17 +105,20 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: setup ubuntu
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get --quiet update --yes
           sudo apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
 
       - name: setup JDK 1.8
+        if: runner.os == 'Linux'
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
 
       - name: download Android SDK
+        if: runner.os == 'Linux'
         run: |
           wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip
           unzip -d android-sdk-linux android-sdk.zip
@@ -131,16 +134,20 @@ jobs:
           set -o pipefail
 
       - name: install Android NDK
+        if: runner.os == 'Linux'
         run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" 
 
       - name: Insert NDK path
+        if: runner.os == 'Linux'
         run: |
           echo "ndk.dir=$PWD/ndk/${{ matrix.ndk-version }}" >> ./local.properties
 
       - name: Install ninja-build tool
+        if: runner.os == 'Linux'
         uses: seanmiddleditch/gha-setup-ninja@v3
 
-      - name: Configure CMake
+      - name: Configure CMake for Android
+        if: runner.os == 'Linux'
         run: >
           cmake
           -S ${{github.workspace}} 
@@ -152,36 +159,8 @@ jobs:
           -D CMAKE_BUILD_TYPE=Release
           -D CMAKE_TOOLCHAIN_FILE=$PWD/ndk/${{ matrix.ndk-version }}/build/cmake/android.toolchain.cmake
 
-      - name: Build by CMake
-        run: cmake --build ${{github.workspace}}/out/build/x64-Release --config Release
-
-
-
-
-
-  # 3つ目のジョブ。
-  # iOS用にライブラリをビルド。
-  upload_ios_dlls:
-
-    runs-on: macos-latest
-
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Add SSH private keys for submodule repositories
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.KEY_TO_ACCESS_FBXSDK }}
-
-      - name: checkout submodules
-        shell: bash
-        run: git submodule update --init --recursive
-
-      - name: Configure CMake
+      - name: Configure CMake for iOS
+        if: runner.os == 'MacOS'
         run: >
           cmake
           -S ${{github.workspace}} 
@@ -198,9 +177,7 @@ jobs:
 
 
 
-
-
-  # 4つ目のジョブです。
+  # 3つ目のジョブです。
   # OSごとのアーティファクトを1つにまとめます。
   sum-up-dlls:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -135,7 +135,7 @@ jobs:
           echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "build-tools;${{ matrix.build-tools }}" >/dev/null
           export ANDROID_SDK_ROOT=$PWD
           export PATH=$PATH:$PWD/platform-tools/
-          chmod +x ./gradlew
+#          chmod +x ./gradlew
           set +o pipefail
           yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
           set -o pipefail

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -124,7 +124,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: download Android SDK
-        working-directory: ${{ matrix.root-project-path }}
+        #working-directory: ${{ matrix.root-project-path }}
         run: |
           wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip
           unzip -d android-sdk-linux android-sdk.zip
@@ -140,10 +140,10 @@ jobs:
           yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
           set -o pipefail
       - name: install Android NDK
-        working-directory: ${{ matrix.root-project-path }}
+        #working-directory: ${{ matrix.root-project-path }}
         run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" "cmake;${{ matrix.cmake-version }}"
       - name: Insert NDK path
-        working-directory: ${{ matrix.root-project-path }}
+        #working-directory: ${{ matrix.root-project-path }}
         run: |
           echo "ndk.dir=$PWD/ndk/${{ matrix.ndk-version }}" >> ./local.properties
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -135,7 +135,7 @@ jobs:
           echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "build-tools;${{ matrix.build-tools }}" >/dev/null
           export ANDROID_SDK_ROOT=$PWD
           export PATH=$PATH:$PWD/platform-tools/
-#          chmod +x ./gradlew
+##          chmod +x ./gradlew
           set +o pipefail
           yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
           set -o pipefail

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -175,17 +175,17 @@ jobs:
 
       - name: Upload framework for Android
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: libplateau-android-dll
           path: ${{github.workspace}}/out/build/x64-Release/src/libplateau.so
 
       - name: Upload framework for iOS
         if: runner.os == 'MacOS'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: libplateau-ios-dll
-          path: ${{github.workspace}}/out/build/x64-Release/src/Release-iphoneos/plateau.framework
+          path: ${{github.workspace}}/out/build/x64-Release/src/Release-iphoneos/plateau.framework/*
 
   # 3つ目のジョブです。
   # OSごとのアーティファクトを1つにまとめます。
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: download-all-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           path: ~/a
 
@@ -206,13 +206,13 @@ jobs:
           mkdir -p ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
           mkdir -p ~/a/plateau-plugins/dynamic-libs/ManagedDLL
           mkdir -p ~/a/plateau-plugins/dynamic-libs/Android
-          mkdir -p ~/a/plateau-plugins/dynamic-libs/iOS
+          mkdir -p ~/a/plateau-plugins/dynamic-libs/iOS/plateau.framework
           cp ~/a/libplateau-windows-dll/plateau.dll ~/a/plateau-plugins/dynamic-libs/Windows/x86_64
           cp ~/a/libplateau-windows-dll/CSharpPLATEAU.dll ~/a/plateau-plugins/dynamic-libs/ManagedDLL
           cp ~/a/libplateau-ubuntu-18.04-dll/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           cp ~/a/libplateau-macos-latest-dll/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
           cp ~/a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
-          cp -r ~/a/libplateau-ios-dll/plateau.framework ~/a/plateau-plugins/dynamic-libs/iOS
+          cp ~/a/libplateau-ios-dll/* ~/a/plateau-plugins/dynamic-libs/iOS/plateau.framework
 
       - name: sum-up-static-libs
         run: |

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -90,7 +90,6 @@ jobs:
         compile-sdk: [33]
         build-tools: [30.0.3]
         ndk-version: [23.1.7779620]
-        cmake-version: [3.22.0]
         root-project-path: [./AndroidNDK]
 
     steps:
@@ -140,7 +139,7 @@ jobs:
           set -o pipefail
       - name: install Android NDK
         #working-directory: ${{ matrix.root-project-path }}
-        run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" "cmake;${{ matrix.cmake-version }}"
+        run: android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --install "ndk;${{ matrix.ndk-version }}" 
       - name: Insert NDK path
         #working-directory: ${{ matrix.root-project-path }}
         run: |

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -147,6 +147,24 @@ jobs:
 
 
 
+      - name: Install ninja-build tool
+        uses: seanmiddleditch/gha-setup-ninja@v3
+
+      - name: Configure CMake
+        run: >
+          cmake
+          -S ${{github.workspace}} 
+          -B ${{github.workspace}}/out/build/x64-Release 
+          -G "Ninja" 
+          -D ANDROID_PLATFORM=android-23
+          -D ANDROID_ABI=arm64-v8a 
+          -D CMAKE_MAKE_PROGRAM=ninja
+          -D CMAKE_BUILD_TYPE=Release
+          -DCMAKE_TOOLCHAIN_FILE=$PWD/ndk/${{ matrix.ndk-version }}/build/cmake/android.toolchain.cmake
+
+      - name: Build by CMake
+        run: cmake --build ${{github.workspace}}/out/build/x64-Release --config Release
+
 
 
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -211,8 +211,8 @@ jobs:
           cp ~/a/libplateau-windows-dll/CSharpPLATEAU.dll ~/a/plateau-plugins/dynamic-libs/ManagedDLL
           cp ~/a/libplateau-ubuntu-18.04-dll/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           cp ~/a/libplateau-macos-latest-dll/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
-          cp ~a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
-          cp -r ~a/libplateau-ios-dll/plateau.framework ~/a/plateau-plugins/dynamic-libs/iOS
+          cp ~/a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
+          cp -r ~/a/libplateau-ios-dll/plateau.framework ~/a/plateau-plugins/dynamic-libs/iOS
 
       - name: sum-up-static-libs
         run: |

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -82,10 +82,11 @@ jobs:
   # AndroidとiOS用にライブラリをビルド。
   upload_mobile_dlls:
 
-    runs-on: [macos-latest, ubuntu-latest]
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, ubuntu-latest]
         compile-sdk: [33]
         build-tools: [30.0.3]
         ndk-version: [23.1.7779620]

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -135,7 +135,6 @@ jobs:
           echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. "build-tools;${{ matrix.build-tools }}" >/dev/null
           export ANDROID_SDK_ROOT=$PWD
           export PATH=$PATH:$PWD/platform-tools/
-##          chmod +x ./gradlew
           set +o pipefail
           yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=. --licenses
           set -o pipefail

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -181,6 +181,18 @@ jobs:
         shell: bash
         run: git submodule update --init --recursive
 
+      - name: Configure CMake
+        run: >
+          cmake
+          -S ${{github.workspace}} 
+          -B ${{github.workspace}}/out/build/x64-Release 
+          -G "Xcode" 
+          -D CMAKE_SYSTEM_NAME=iOS
+          -D CMAKE_OSX_DEPLOYMENT_TARGET=13.0
+          -D CMAKE_BUILD_TYPE=Release
+
+      - name: Build by CMake
+        run: cmake --build ${{github.workspace}}/out/build/x64-Release --config Release
 
 
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -82,8 +82,7 @@ jobs:
   # AndroidとiOS用にライブラリをビルド。
   upload_mobile_dlls:
 
-    runs-on: [ubuntu-latest, macos-latest]
-
+    runs-on: [macos-latest, ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -5,10 +5,9 @@ name: Upload DLLs
 
 # 手動でgithubサイトのボタンを押したときか、タグを作ったときに実行します。
 on:
-  push:
-  #workflow_dispatch:
-  #create:
-  #  tags: '*'
+  workflow_dispatch:
+  create:
+    tags: '*'
 
 env:
   BUILD_TYPE: RelWithDebInfo

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -175,14 +175,14 @@ jobs:
 
       - name: Upload framework for Android
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: libplateau-android-dll
           path: ${{github.workspace}}/out/build/x64-Release/src/libplateau.so
 
       - name: Upload framework for iOS
         if: runner.os == 'MacOS'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: libplateau-ios-dll
           path: ${{github.workspace}}/out/build/x64-Release/src/Release-iphoneos/plateau.framework
@@ -195,7 +195,7 @@ jobs:
 
     steps:
       - name: download-all-artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ~/a
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -173,15 +173,25 @@ jobs:
       - name: Build by CMake
         run: cmake --build ${{github.workspace}}/out/build/x64-Release --config Release
 
+      - name: Upload framework for Android
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: libplateau-android-dll
+          path: ${{github.workspace}}/out/build/x64-Release/src/libplateau.so
 
-
-
+      - name: Upload framework for iOS
+        if: runner.os == 'MacOS'
+        uses: actions/upload-artifact@v2
+        with:
+          name: libplateau-ios-dll
+          path: ${{github.workspace}}/out/build/x64-Release/src/plateau.framework
 
   # 3つ目のジョブです。
   # OSごとのアーティファクトを1つにまとめます。
   sum-up-dlls:
     runs-on: ubuntu-latest
-    needs: upload-dlls
+    needs: [upload-dlls, upload_mobile_dlls]
 
     steps:
       - name: download-all-artifacts
@@ -195,10 +205,14 @@ jobs:
           mkdir -p ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           mkdir -p ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
           mkdir -p ~/a/plateau-plugins/dynamic-libs/ManagedDLL
+          mkdir -p ~/a/plateau-plugins/dynamic-libs/Android
+          mkdir -p ~/a/plateau-plugins/dynamic-libs/iOS
           cp ~/a/libplateau-windows-dll/plateau.dll ~/a/plateau-plugins/dynamic-libs/Windows/x86_64
           cp ~/a/libplateau-windows-dll/CSharpPLATEAU.dll ~/a/plateau-plugins/dynamic-libs/ManagedDLL
           cp ~/a/libplateau-ubuntu-18.04-dll/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           cp ~/a/libplateau-macos-latest-dll/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
+          cp ~a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
+          cp -r ~a/libplateau-ios-dll/plateau.framework ~/a/plateau-plugins/dynamic-libs/iOS
 
       - name: sum-up-static-libs
         run: |


### PR DESCRIPTION
## 関連リンク
<!-- libcitygmlのPR等、関連するPRがあれば書く。 -->

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
iOSとAndroidでもActionsからUpload DLLsでライブラリがダウンロード出来るようにしました。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [x] 自動ビルド・テストが通っていること
- [x] Squash and Mergeが選択されていること
- [x] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
