### PR TITLE
ツール Licensed を使って、push時にsubmoduleのライセンスチェックが自動で走るようにしました。

### DIFF
--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -1,4 +1,5 @@
 # licensed というツールを使って submodule のライセンスをチェックします。
+# このCIに失敗する場合、 .licensed.yml という名前のファイルを見直してください。
 
 # 参考 : licensed について
 # https://github.com/github/licensed

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -1,5 +1,11 @@
 # licensed というツールを使って submodule のライセンスをチェックします。
 
+# 参考 : licensed について
+# https://github.com/github/licensed
+
+# 参考 : licensed の CI 利用について
+# https://github.com/marketplace/actions/setup-github-licensed
+
 name: Check Submodule License
 
 on:
@@ -15,8 +21,12 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
-        with:
-          version: '4.x'
+      with:
+        ruby-version: ruby
+
+    - uses: jonabc/setup-licensed@v1
+      with:
+        version: '4.x'
 
     - run: licensed cache
     - run: licensed status

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -1,0 +1,22 @@
+# licensed というツールを使って submodule のライセンスをチェックします。
+
+name: Check Submodule License
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  check-submodule-license:
+    runs-on: ubuntu-20.04
+
+  steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: ruby/setup-ruby@v1
+        with:
+          version: '4.x'
+
+    - run: licensed cache
+    - run: licensed status

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -16,17 +16,17 @@ jobs:
   check-submodule-license:
     runs-on: ubuntu-20.04
 
-  steps:
+    steps:
 
-  - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-  - uses: ruby/setup-ruby@v1
-    with:
-      ruby-version: ruby
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
 
-  - uses: jonabc/setup-licensed@v1
-    with:
-      version: '4.x'
+    - uses: jonabc/setup-licensed@v1
+      with:
+        version: '4.x'
 
-  - run: licensed cache
-  - run: licensed status
+    - run: licensed cache
+    - run: licensed status

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -18,15 +18,15 @@ jobs:
 
   steps:
 
-    - uses: actions/checkout@v3
+  - uses: actions/checkout@v3
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ruby
+  - uses: ruby/setup-ruby@v1
+    with:
+      ruby-version: ruby
 
-    - uses: jonabc/setup-licensed@v1
-      with:
-        version: '4.x'
+  - uses: jonabc/setup-licensed@v1
+    with:
+      version: '4.x'
 
-    - run: licensed cache
-    - run: licensed status
+  - run: licensed cache
+  - run: licensed status

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -21,6 +21,10 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    - name: checkout submodules
+      shell: bash
+      run: git submodule update --init --recursive
+
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # fbx_sdk は再配布禁止のため、ご自分で用意していただく形になります。
 /3rdparty/fbx_sdk/
 
+# licensed ツールのキャッシュフォルダです。
+.licenses/*
+
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -9,7 +9,7 @@ allowed:
 
 reviewed:
   git_submodule:
-    - libxml2 # MITライセンスなのでOK
+    # - libxml2 # MITライセンスなのでOK
     - openssl-cmake # 再配布可能、要著作権表示
     - pybind11 # BSD-3ライセンスなのでOK
     - zlib # 再配布可能、要ライセンス表示

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,8 @@
+# submodule のライセンスをチェックする licensed というツールの設定ファイルです。
+
+allowed:
+  - mit
+  - bsd-2-clause
+  - bsd-3-clause
+  - cc0-1.0
+  - apache-2.0

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -9,7 +9,7 @@ allowed:
 
 reviewed:
   git_submodule:
-    # - libxml2 # MITライセンスなのでOK
+    - libxml2 # MITライセンスなのでOK
     - openssl-cmake # 再配布可能、要著作権表示
     - pybind11 # BSD-3ライセンスなのでOK
     - zlib # 再配布可能、要ライセンス表示

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -6,3 +6,11 @@ allowed:
   - bsd-3-clause
   - cc0-1.0
   - apache-2.0
+
+reviewed:
+  git_submodule:
+    - libxml2 # MITライセンスなのでOK
+    - openssl-cmake # 再配布可能、要著作権表示
+    - pybind11 # BSD-3ライセンスなのでOK
+    - zlib # 再配布可能、要ライセンス表示
+    - libcitygml # LGPLライセンス、改変部分をpublicリポジトリで公開しているのでOK

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+
+# Submoduleのライセンスを確認するためのツールです。
+gem 'licensed', :group => 'development'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    dotenv (2.8.1)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    json (2.6.3)
+    licensed (4.3.0)
+      json (~> 2.6)
+      licensee (~> 9.16)
+      parallel (~> 1.22)
+      pathname-common_prefix (~> 0.0.1)
+      reverse_markdown (~> 2.1)
+      ruby-xxHash (~> 0.4.0)
+      thor (~> 1.2)
+      tomlrb (~> 2.0)
+    licensee (9.16.0)
+      dotenv (~> 2.0)
+      octokit (>= 4.20, < 7.0)
+      reverse_markdown (>= 1, < 3)
+      rugged (>= 0.24, < 2.0)
+      thor (>= 0.19, < 2.0)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
+    octokit (6.1.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    parallel (1.22.1)
+    pathname-common_prefix (0.0.1)
+    public_suffix (5.0.1)
+    racc (1.6.2)
+    reverse_markdown (2.1.1)
+      nokogiri
+    ruby-xxHash (0.4.0.2)
+    ruby2_keywords (0.0.5)
+    rugged (1.6.3)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    thor (1.2.1)
+    tomlrb (2.0.3)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  licensed
+
+BUNDLED WITH
+   2.4.6


### PR DESCRIPTION
## 実装内容
- Lisenced を使った CI チェックが走るようにしました。
- 今使っている submodule はチェック済みとするよう Licensed の設定ファイルを書きました。

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
github actionsの履歴から Check Submodule Licenses ビルドが動いているのを確認できます。
