### PR TITLE
SDK for UnrealをMacでビルドしたときに警告がたくさん出る問題を修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,10 @@ endif()
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
 
-# このバージョン数値は Unreal Engine と合わせないと Unreal SDK ビルド時に大量の警
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+if(NOT IOS)
+  # このバージョン数値は Unreal Engine と合わせないと Unreal SDK ビルド時に大量の警告が出ます
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+endif()
 
 project("libplateau")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ endif()
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
 
+# このバージョン数値は Unreal Engine と合わせないと Unreal SDK ビルド時に大量の警告が出ます
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 project("libplateau")
 
 set(LIBPLATEAU_BINARY_DIR ${libplateau_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
 
-# このバージョン数値は Unreal Engine と合わせないと Unreal SDK ビルド時に大量の警告が出ます
+# このバージョン数値は Unreal Engine と合わせないと Unreal SDK ビルド時に大量の警
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 
 project("libplateau")

--- a/include/plateau/basemap/vector_tile_downloader.h
+++ b/include/plateau/basemap/vector_tile_downloader.h
@@ -76,7 +76,7 @@ public:
     static const std::string& getDefaultUrl();
 
 private:
-    static inline std::string default_url_ = "http://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png";
+    static const std::string default_url_;
 
     std::string url_;
     std::string destination_;

--- a/include/plateau/dataset/i_dataset_accessor.h
+++ b/include/plateau/dataset/i_dataset_accessor.h
@@ -18,31 +18,6 @@ namespace plateau::dataset {
             : name_(std::move(name)) {
         }
 
-        //! 建築物、建築物部分、建築物付属物及びこれらの境界面
-        inline static const std::string bldg = "bldg";
-        //! 道路
-        inline static const std::string tran = "tran";
-        //! 都市計画決定情報
-        inline static const std::string urf = "urf";
-        //! 土地利用
-        inline static const std::string luse = "luse";
-        //! 都市設備
-        inline static const std::string frn = "frn";
-        //! 植生
-        inline static const std::string veg = "veg";
-        //! 起伏
-        inline static const std::string dem = "dem";
-        //! 洪水浸水想定区域
-        inline static const std::string fld = "fld";
-        //! 津波浸水想定
-        inline static const std::string tnm = "tnm";
-        //! 土砂災害警戒区域
-        inline static const std::string lsld = "lsld";
-        //! 高潮浸水想定区域
-        inline static const std::string htd = "htd";
-        //! 内水浸水想定区域
-        inline static const std::string ifld = "ifld";
-
         static PredefinedCityModelPackage getPackage(const std::string& folder_name);
         static CityModelPackageInfo getPackageInfo(const std::string& folder_name);
 
@@ -60,6 +35,31 @@ namespace plateau::dataset {
 
     private:
         std::string name_;
+
+        //! 建築物、建築物部分、建築物付属物及びこれらの境界面
+        static const std::string bldg;
+        //! 道路
+        static const std::string tran;
+        //! 都市計画決定情報
+        static const std::string urf;
+        //! 土地利用
+        static const std::string luse;
+        //! 都市設備
+        static const std::string frn;
+        //! 植生
+        static const std::string veg;
+        //! 起伏
+        static const std::string dem;
+        //! 洪水浸水想定区域
+        static const std::string fld;
+        //! 津波浸水想定
+        static const std::string tnm;
+        //! 土砂災害警戒区域
+        static const std::string lsld;
+        //! 高潮浸水想定区域
+        static const std::string htd;
+        //! 内水浸水想定区域
+        static const std::string ifld;
     };
 
     class LIBPLATEAU_EXPORT IDatasetAccessor {

--- a/src/basemap/vector_tile_downloader.cpp
+++ b/src/basemap/vector_tile_downloader.cpp
@@ -8,6 +8,8 @@
 
 namespace fs = std::filesystem;
 
+const std::string VectorTileDownloader::default_url_ = "http://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png";
+
 VectorTileDownloader::VectorTileDownloader(
     const std::string& destination,
     const plateau::geometry::Extent& extent,

--- a/src/dataset/local_dataset_accessor.cpp
+++ b/src/dataset/local_dataset_accessor.cpp
@@ -11,6 +11,31 @@ namespace plateau::dataset {
     namespace fs = std::filesystem;
     using namespace geometry;
 
+    //! 建築物、建築物部分、建築物付属物及びこれらの境界面
+    const std::string UdxSubFolder::bldg = "bldg";
+    //! 道路
+    const std::string UdxSubFolder::tran = "tran";
+    //! 都市計画決定情報
+    const std::string UdxSubFolder::urf = "urf";
+    //! 土地利用
+    const std::string UdxSubFolder::luse = "luse";
+    //! 都市設備
+    const std::string UdxSubFolder::frn = "frn";
+    //! 植生
+    const std::string UdxSubFolder::veg = "veg";
+    //! 起伏
+    const std::string UdxSubFolder::dem = "dem";
+    //! 洪水浸水想定区域
+    const std::string UdxSubFolder::fld = "fld";
+    //! 津波浸水想定
+    const std::string UdxSubFolder::tnm = "tnm";
+    //! 土砂災害警戒区域
+    const std::string UdxSubFolder::lsld = "lsld";
+    //! 高潮浸水想定区域
+    const std::string UdxSubFolder::htd = "htd";
+    //! 内水浸水想定区域
+    const std::string UdxSubFolder::ifld = "ifld";
+
     PredefinedCityModelPackage UdxSubFolder::getPackage(const std::string& folder_name) {
         if (folder_name == bldg) return PredefinedCityModelPackage::Building;
         if (folder_name == tran) return PredefinedCityModelPackage::Road;


### PR DESCRIPTION
## 実装内容
Unrealビルド時の警告を修正するため、
- CMakeLists.txt を修正しました。
- `static inline` を使うと警告が出るので、`static const` に置き換えました

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
MacでのUnrealビルド時に警告が減ります。  
(SDK for Unreal自体の警告はあります。)
