### PR TITLE
タイル画像ダウンロード時のエラーハンドリング

### DIFF
--- a/include/plateau/basemap/vector_tile_downloader.h
+++ b/include/plateau/basemap/vector_tile_downloader.h
@@ -6,6 +6,26 @@
 #include "plateau/geometry/geo_coordinate.h"
 
 /**
+ * Http通信のエラーです。(Httplib::Error)
+ */
+enum class HttpResult {
+    Success = 0,
+    Unknown,
+    Connection,
+    BindIPAddress,
+    Read,
+    Write,
+    ExceedRedirectCount,
+    Canceled,
+    SSLConnection,
+    SSLLoadingCerts,
+    SSLServerVerification,
+    UnsupportedMultipartBoundaryChars,
+    Compression,
+    ConnectionTimeout,
+};
+
+/**
  * 地理院地図のタイル情報です。
  * 具体的なタイル座標情報についてはこちらを参照してください。
  * https://maps.gsi.go.jp/development/tileCoordCheck.html
@@ -22,6 +42,7 @@ struct TileCoordinate {
 struct VectorTile {
     TileCoordinate coordinate{};
     std::string image_path;
+    HttpResult result;
 };
 
 /**

--- a/src/basemap/vector_tile_downloader.cpp
+++ b/src/basemap/vector_tile_downloader.cpp
@@ -54,6 +54,8 @@ void VectorTileDownloader::download(
 
     httplib::Client client(host);
     std::string body;
+    client.set_connection_timeout(1, 0);
+
     auto result = client.Get(
         path, httplib::Headers(),
         [&](const httplib::Response& response) {
@@ -63,6 +65,11 @@ void VectorTileDownloader::download(
             body.append(data, data_length);
             return true; // return 'false' if you want to cancel the request.
         });
+
+    if (result.error() != httplib::Error::Success) {
+        out_vector_tile.image_path.clear();
+        return;
+        }
 
     auto file_path = calcDestinationPath(coordinate, destination);
     create_directories(file_path.parent_path());

--- a/src/basemap/vector_tile_downloader.cpp
+++ b/src/basemap/vector_tile_downloader.cpp
@@ -51,10 +51,9 @@ void VectorTileDownloader::download(
     std::string host = strs[0] + "/" + strs[1] + "/" + strs[2];
     std::string path = "/" + strs[3] + "/" + strs[4] + "/" + std::to_string(coordinate.zoom_level) + "/" + std::to_string(coordinate.column) + "/" + std::to_string(coordinate.row) + ".png";
 
-
     httplib::Client client(host);
     std::string body;
-    client.set_connection_timeout(1, 0);
+    client.set_connection_timeout(5, 0);
 
     auto result = client.Get(
         path, httplib::Headers(),
@@ -68,8 +67,9 @@ void VectorTileDownloader::download(
 
     if (result.error() != httplib::Error::Success) {
         out_vector_tile.image_path.clear();
+        out_vector_tile.result = static_cast<HttpResult>(result.error());
         return;
-        }
+    }
 
     auto file_path = calcDestinationPath(coordinate, destination);
     create_directories(file_path.parent_path());

--- a/src/c_wrapper/vector_tile_downloader_c.cpp
+++ b/src/c_wrapper/vector_tile_downloader_c.cpp
@@ -34,6 +34,7 @@ using namespace plateau::geometry;
             }
             auto result = downloader->download(index, tile);
             if(!result) return APIResult::ErrorValueNotFound;
+            if(tile.result != HttpResult::Success) return APIResult::ErrorValueNotFound;
             return APIResult::Success;
         } API_CATCH
         return APIResult::ErrorUnknown;


### PR DESCRIPTION
## 関連リンク
<!-- libcitygmlのPR等、関連するPRがあれば書く。 -->

## 実装内容
httplibで通信エラー発生時、エラー内容を返却
通信タイムアウトを５秒に設定

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
