### PR TITLE
LOD検索バグ修正、ユニットテスト追加修正、VS2022に変更

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -85,7 +85,7 @@ runs:
         cmake
         -S ${{github.workspace}}
         -B ${{github.workspace}}/out/build/x64-Release-Unreal
-        -G "Visual Studio 16 2019"
+        -G "Visual Studio 17 2022"
         -D CMAKE_INSTALL_PREFIX="C:/ninja"
         -D CMAKE_BUILD_TYPE:STRING="${{env.BUILDTYPE}}"
         -D CMAKE_CXX_FLAGS="-w"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-latest, ubuntu-20.04]
+        os: [windows-2022, macos-latest, ubuntu-20.04]
 
     steps:
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-latest, ubuntu-20.04]
+        os: [windows-2022, macos-latest, ubuntu-20.04]
 
     steps:
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# デフォルトの無視対象ファイル
+/shelf/
+/workspace.xml
+# エディターベースの HTTP クライアントリクエスト
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Unreal-Release" ENABLED="true" GENERATION_DIR="out/build/x64-Release-Unreal" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G &quot;Visual Studio 17 2022&quot; -DCMAKE_INSTALL_PREFIX=&quot;C:/ninja&quot; -DCMAKE_BUILD_TYPE=RelWithDebInfo" />
+      <configuration PROFILE_NAME="Unreal-Debug" ENABLED="true" GENERATION_DIR="out/build/x64-Debug-Unreal" CONFIG_NAME="Release" GENERATION_OPTIONS="-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G &quot;Visual Studio 17 2022&quot; -DCMAKE_INSTALL_PREFIX=&quot;C:/ninja&quot; -DCMAKE_BUILD_TYPE=Debug" />
+      <configuration PROFILE_NAME="Unity-Release" ENABLED="true" GENERATION_DIR="out/build/x64-Release-Unity" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DBUILD_LIB_TYPE=dynamic -DRUNTIME_LIB_TYPE=MT" />
+      <configuration PROFILE_NAME="Unity-Debug" ENABLED="true" GENERATION_DIR="out/build/x64-Debug-Unity" CONFIG_NAME="Debug" GENERATION_OPTIONS="-DBUILD_LIB_TYPE=dynamic -DRUNTIME_LIB_TYPE=MD" />
+    </configurations>
+  </component>
+</project>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,10 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <Objective-C>
+      <option name="SPACE_BEFORE_POINTER_IN_DECLARATION" value="false" />
+      <option name="SPACE_AFTER_POINTER_IN_DECLARATION" value="true" />
+      <option name="SPACE_BEFORE_REFERENCE_IN_DECLARATION" value="false" />
+      <option name="SPACE_AFTER_REFERENCE_IN_DECLARATION" value="true" />
+    </Objective-C>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/libplateau.iml
+++ b/.idea/libplateau.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/libplateau.iml" filepath="$PROJECT_DIR$/.idea/libplateau.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,6 +3,7 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/cpp-httplib" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/fbx_sdk" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/glTF-SDK/glTF-SDK" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/json" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/libcitygml" vcs="Git" />
@@ -10,6 +11,8 @@
     <mapping directory="$PROJECT_DIR$/3rdparty/openssl-cmake" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/xerces-c" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/zlib" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Debug-Unity/RapidJSON-src" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Debug-Unity/RapidJSON-src/thirdparty/gtest" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/test/gtest" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/wrappers/python/pybind11" vcs="Git" />
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/cpp-httplib" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/glTF-SDK/glTF-SDK" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/json" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/libcitygml" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/libxml2" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/openssl-cmake" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/xerces-c" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/3rdparty/zlib" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/test/gtest" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/wrappers/python/pybind11" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fbx_sdk は Autodesk社が公開するSDKです。これは自由に製品に組
 
 #### 2. C++, C# のビルド手順
 - C++ は、CMake を使ってビルドします。CMake は、 Visaul Studio, CLion, コマンド のどれからでも利用できます。
-- Visual Studio のバージョンについては、 Unreal Engine向けのSDK が Visual Studio 2019 を想定しているので、2019を推奨します。 
+- Visual Studio のバージョンについては、 Unreal Engine向けのSDK が Visual Studio 2022 を想定しているので、2022を推奨します。 
   - Visual Studioを利用する場合、 CMake でビルドするために C++によるデスクトップ開発ツールがインストールされているか確認してください。
     - 確認方法は、Visual Studio Insttaller を起動 → Visual Studio Community の"変更"ボタン → "C++によるデスクトップ開発" にチェックが入っているか確認してください。
     - 入っていなければインストールしてください。
@@ -72,7 +72,7 @@ fbx_sdk は Autodesk社が公開するSDKです。これは自由に製品に組
     - ビルドタイプ : `RelWithDebInfo`
     - ビルドディレクトリ : `out/build/x64-Release-Unreal`
     - CMakeコマンド引数(Visual Studio向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD`
-    - CMakeオプション(CLion向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G "Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX="C:/ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo`
+    - CMakeオプション(CLion向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX="C:/ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo`
 
   - **Mac, Linux** : Unreal向けDebug
     - ビルドタイプ(構成の種類,CMAKE_BUILD_TYPE) : `Debug`
@@ -83,7 +83,7 @@ fbx_sdk は Autodesk社が公開するSDKです。これは自由に製品に組
     - ビルドタイプ(構成の種類,CMAKE_BUILD_TYPE) : `Debug`
     - ビルドディレクトリ : `out/build/x64-Debug-Unreal`
     - CMakeコマンド引数(Visual Studio向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD`
-    - CMakeオプション(CLion向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G "Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX="C:/ninja" -DCMAKE_BUILD_TYPE=Debug`
+    - CMakeオプション(CLion向け) : `-DBUILD_LIB_TYPE=static -DRUNTIME_LIB_TYPE=MD -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX="C:/ninja" -DCMAKE_BUILD_TYPE=Debug`
 
 - C++ の libplateau をビルドすると、Unity向けの場合は DLL ができます。
   - 詳しくは下記の、各OS向けのビルド手順を参照してください。

--- a/include/plateau/dataset/lod_searcher.h
+++ b/include/plateau/dataset/lod_searcher.h
@@ -14,6 +14,7 @@ namespace plateau::dataset {
     class LIBPLATEAU_EXPORT LodSearcher {
     public:
         static plateau::dataset::LodFlag searchLodsInFile(const std::filesystem::path& file_path);
+        static plateau::dataset::LodFlag searchLodsInIstream(std::istream& ifs);
     };
 
     /// どのLODが含まれるかをフラグ(unsigned)で表現します。

--- a/src/dataset/gml_file.cpp
+++ b/src/dataset/gml_file.cpp
@@ -8,8 +8,7 @@
 #include <plateau/dataset/gml_file.h>
 #include <plateau/dataset/mesh_code.h>
 #include <plateau/network/client.h>
-
-#include "lod_searcher.h"
+#include <plateau/dataset/lod_searcher.h>
 
 using namespace plateau::network;
 namespace fs = std::filesystem;

--- a/src/dataset/lod_searcher.cpp
+++ b/src/dataset/lod_searcher.cpp
@@ -1,4 +1,4 @@
-#include "lod_searcher.h"
+#include <plateau/dataset/lod_searcher.h>
 #include <fstream>
 #include <stdexcept>
 #include <cstring>
@@ -26,51 +26,6 @@ namespace {
         }
     }
 
-    LodFlag searchLods(std::ifstream& ifs) {
-        // 注意:
-        // この関数は実行速度にこだわる必要があります。
-        // 用途はPLATEAUデータのインポートにおける範囲選択画面で、多くのGMLファイルについて利用可能なLODを検索します。
-
-        // 文字列検索で ":lod" にヒットした直後の数値をLODとします。
-        const static auto lod_pattern = u8":lod";
-        const static auto lod_pattern_size = strlen(lod_pattern);
-
-        auto lod_flag = LodFlag();
-
-        // GMLファイルを全部メモリに読み込むと重いので、16KBごとに分割して読み込みます。
-        // 分割された1つを チャンク(chunk) と名付けます。
-        constexpr int chunk_size = 16 * 1024;
-        char chunk[chunk_size];
-        const char* const chunk_const = chunk;
-
-        ifs.read(chunk, sizeof chunk);
-        auto read_size = ifs.gcount();
-        while (!ifs.eof()) {
-            const char* const chunk_last = chunk_const + read_size - 1; // チャンク内の最後の文字のポインタ
-            // チャンク内での文字列検索を始めます。 ":lod" を探します。
-            const char* found_ptr = strstr(chunk, lod_pattern);
-
-            // ":lod" がヒットするたびに、その直後の数字をLODとみなして取得します。
-            while (found_ptr) {
-                // ":lod"の直後が数字であれば、そのLODをセット
-                readCharAndSetLod(found_ptr, lod_pattern_size, 0, chunk_last, lod_flag);
-                // ":lod" の直後が ">" であれば、 ":lod>"の直後の数字のLODをセット (dem向け)
-                if(*getCharPtr(found_ptr, lod_pattern_size, 0, chunk_last) == u8'>'){
-                    readCharAndSetLod(found_ptr, lod_pattern_size, 1, chunk_last, lod_flag);
-                }
-
-                // チャンク内の次の ":lod" を探します。
-                auto next_pos = std::min(found_ptr + lod_pattern_size, chunk_last);
-                found_ptr = strstr(next_pos, lod_pattern);
-            }
-            // 次のチャンクに移ります。
-            ifs.read(chunk, sizeof chunk);
-            read_size = ifs.gcount();
-        }
-
-
-        return lod_flag;
-    }
 }
 
 LodFlag LodSearcher::searchLodsInFile(const fs::path& file_path) {
@@ -78,7 +33,53 @@ LodFlag LodSearcher::searchLodsInFile(const fs::path& file_path) {
     if (!ifs) {
         throw std::runtime_error("Failed to read file.");
     }
-    return searchLods(ifs);
+    return searchLodsInIstream(ifs);
+}
+
+LodFlag LodSearcher::searchLodsInIstream(std::istream& ifs) {
+    // 注意:
+    // この関数は実行速度にこだわる必要があります。
+    // 用途はPLATEAUデータのインポートにおける範囲選択画面で、多くのGMLファイルについて利用可能なLODを検索します。
+
+    // 文字列検索で ":lod" にヒットした直後の数値をLODとします。
+    const static auto lod_pattern = u8":lod";
+    const static auto lod_pattern_size = strlen(lod_pattern);
+
+    auto lod_flag = LodFlag();
+
+    // GMLファイルを全部メモリに読み込むと重いので、16KBごとに分割して読み込みます。
+    // 分割された1つを チャンク(chunk) と名付けます。
+    constexpr int chunk_size = 16 * 1024;
+    char chunk[chunk_size];
+    const char* const chunk_const = chunk;
+
+    ifs.read(chunk, sizeof chunk);
+    auto read_size = ifs.gcount();
+    do {
+        const char* const chunk_last = chunk_const + read_size - 1; // チャンク内の最後の文字のポインタ
+        // チャンク内での文字列検索を始めます。 ":lod" を探します。
+        const char* found_ptr = strstr(chunk, lod_pattern);
+
+        // ":lod" がヒットするたびに、その直後の数字をLODとみなして取得します。
+        while (found_ptr) {
+            // ":lod"の直後が数字であれば、そのLODをセット
+            readCharAndSetLod(found_ptr, lod_pattern_size, 0, chunk_last, lod_flag);
+            // ":lod" の直後が ">" であれば、 ":lod>"の直後の数字のLODをセット (dem向け)
+            if (*getCharPtr(found_ptr, lod_pattern_size, 0, chunk_last) == u8'>'){
+                readCharAndSetLod(found_ptr, lod_pattern_size, 1, chunk_last, lod_flag);
+            }
+
+            // チャンク内の次の ":lod" を探します。
+            auto next_pos = std::min(found_ptr + lod_pattern_size, chunk_last);
+            found_ptr = strstr(next_pos, lod_pattern);
+        }
+        // 次のチャンクに移ります。
+        ifs.read(chunk, sizeof chunk);
+        read_size = ifs.gcount();
+    } while (!ifs.eof());
+
+
+    return lod_flag;
 }
 
 

--- a/src/dataset/lod_searcher.cpp
+++ b/src/dataset/lod_searcher.cpp
@@ -38,24 +38,30 @@ LodFlag LodSearcher::searchLodsInFile(const fs::path& file_path) {
 
 LodFlag LodSearcher::searchLodsInIstream(std::istream& ifs) {
     // 注意:
-    // この関数は実行速度にこだわる必要があります。
-    // 用途はPLATEAUデータのインポートにおける範囲選択画面で、多くのGMLファイルについて利用可能なLODを検索します。
+    // この関数は実行速度にこだわる必要があるため、 std::string よりも原始的な C言語の機能を積極的に利用しています。
+    // 用途はPLATEAUデータのインポートにおける範囲選択画面で、GMLファイルについて利用可能なLODを検索します。
+    // 範囲選択画面では多くのGMLファイルを検索対象とするので、高速である必要があります。
 
     // 文字列検索で ":lod" にヒットした直後の数値をLODとします。
     const static auto lod_pattern = u8":lod";
     const static auto lod_pattern_size = strlen(lod_pattern);
 
-    auto lod_flag = LodFlag();
-
     // GMLファイルを全部メモリに読み込むと重いので、16KBごとに分割して読み込みます。
     // 分割された1つを チャンク(chunk) と名付けます。
-    constexpr int chunk_size = 16 * 1024;
-    char chunk[chunk_size];
+    // この手法のデメリットとして、チャンクの切れ目で ":lod(num)" が分断された場合には見逃してしまいます。
+    // しかし、 ":lod(num)" はGML内で何度も登場することを考えれば、低確率で見逃しても他で検知できる確率が高いのでよしとします。
+    constexpr int chunk_read_size = 16 * 1024;
+    constexpr int chunk_mem_size = chunk_read_size + 1; // null終端文字の分
+    char chunk[chunk_mem_size];
     const char* const chunk_const = chunk;
+    auto lod_flag = LodFlag();
 
-    ifs.read(chunk, sizeof chunk);
-    auto read_size = ifs.gcount();
     do {
+        ifs.read(chunk, chunk_read_size);
+        auto read_size = ifs.gcount();
+        // ifstream.read() では null終端文字は付きませんが、付けておかないと下の strstr でバグるので追加します。
+        chunk[read_size] = '\0';
+
         const char* const chunk_last = chunk_const + read_size - 1; // チャンク内の最後の文字のポインタ
         // チャンク内での文字列検索を始めます。 ":lod" を探します。
         const char* found_ptr = strstr(chunk, lod_pattern);
@@ -73,9 +79,6 @@ LodFlag LodSearcher::searchLodsInIstream(std::istream& ifs) {
             auto next_pos = std::min(found_ptr + lod_pattern_size, chunk_last);
             found_ptr = strstr(next_pos, lod_pattern);
         }
-        // 次のチャンクに移ります。
-        ifs.read(chunk, sizeof chunk);
-        read_size = ifs.gcount();
     } while (!ifs.eof());
 
 
@@ -101,6 +104,9 @@ void LodFlag::unsetFlag(unsigned digit) {
     flags_ &= ~(1 << digit);
 }
 
+/// 存在するLODのフラグ列のうち、最大のLODを返します。
+/// LODが存在しない場合は -1 を返します。
+/// LOD i が存在する場合、LOD 0 ～ i-1 も存在することが前提です。
 int LodFlag::getMax() const {
     auto flag = flags_;
     int i = -1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,9 @@ add_executable(plateau_test
     "test_dataset.cpp"
     "test_dataset_source.cpp"
     "test_server_dataset_accessor.cpp"
-    "test_fbx_writer.cpp")
+    "test_fbx_writer.cpp"
+    "test_lod_searcher.cpp"
+        )
 
 target_link_libraries(plateau_test gtest gtest_main plateau citygml)
 

--- a/test/test_dataset_source.cpp
+++ b/test/test_dataset_source.cpp
@@ -26,7 +26,7 @@ namespace plateau::dataset {
         auto source = DatasetSource::createServer(std::string("23ku"), network::Client::createClientForMockServer());
         auto accessor = source.getAccessor();
         auto mesh_code_str = accessor->getMeshCodes().begin()->get();
-        ASSERT_EQ(mesh_code_str, "53392642");
+        ASSERT_EQ(mesh_code_str, "533926");
         auto gml_files = accessor->getGmlFiles(PredefinedCityModelPackage::Building);
         ASSERT_EQ(gml_files->at(0).getMeshCode().get(), "53392642");
     }

--- a/test/test_lod_searcher.cpp
+++ b/test/test_lod_searcher.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <plateau/dataset/lod_searcher.h>
+#include <fstream>
+
+namespace plateau::dataset {
+    class LodSearcherTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+        }
+    };
+
+    namespace {
+        int getMaxLod(const std::string& content) {
+            auto string_buf = std::stringbuf(content);
+            auto istream = std::istream(&string_buf);
+            return LodSearcher::searchLodsInIstream(istream).getMax();
+        }
+    }
+
+    TEST_F(LodSearcherTest, SearchLodReturnsNumAfterLodColon) { // NOLINT
+        ASSERT_EQ(getMaxLod(":lod2"), 2);
+    }
+
+    TEST_F(LodSearcherTest, WhenBodyIsEmptyReturnsMinus1) { // NOLINT
+        ASSERT_EQ(getMaxLod(""), -1);
+    }
+
+    TEST_F(LodSearcherTest, WhenLodIsMissingReturnsMinus1) { // NOLINT
+        ASSERT_EQ(getMaxLod(":lod_is_not_found"), -1);
+    }
+
+    TEST_F(LodSearcherTest, MultipleLods) { // NOLINT
+        ASSERT_EQ(getMaxLod(":lod2:lod3"), 3);
+    }
+}
+

--- a/test/test_lod_searcher.cpp
+++ b/test/test_lod_searcher.cpp
@@ -25,6 +25,10 @@ namespace plateau::dataset {
         ASSERT_EQ(getMaxLod(""), -1);
     }
 
+    TEST_F(LodSearcherTest, WhenBodyIsOneSpaceReturnsMinus1) { // NOLINT
+        ASSERT_EQ(getMaxLod(" "), -1);
+    }
+
     TEST_F(LodSearcherTest, WhenLodIsMissingReturnsMinus1) { // NOLINT
         ASSERT_EQ(getMaxLod(":lod_is_not_found"), -1);
     }

--- a/test/test_server_dataset_accessor.cpp
+++ b/test/test_server_dataset_accessor.cpp
@@ -21,7 +21,7 @@ namespace plateau::dataset {
         const auto dataset_source = DatasetSource::createServer("23ku", network::Client::createClientForMockServer());
         const auto accessor = dataset_source.getAccessor();
         auto packages = accessor->getPackages();
-        ASSERT_EQ((unsigned  long)0b1111, (unsigned long)packages);
+        ASSERT_EQ((unsigned  long)0b1001111, (unsigned long)packages);
     }
 
     TEST_F(ServerDatasetAccessorTest, getmaxLod) { // NOLINT

--- a/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/.gitignore
+++ b/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+/.idea.CSharpPLATEAU.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/.name
+++ b/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/.name
@@ -1,0 +1,1 @@
+CSharpPLATEAU

--- a/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/encodings.xml
+++ b/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/indexLayout.xml
+++ b/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/vcs.xml
+++ b/wrappers/csharp/LibPLATEAU.NET/.idea/.idea.CSharpPLATEAU/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/CityModelPackageInfoTest.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/CityModelPackageInfoTest.cs
@@ -21,7 +21,7 @@ namespace PLATEAU.Test.Dataset
             var buildingPredefined = CityModelPackageInfo.GetPredefined(PredefinedCityModelPackage.Building);
             Assert.AreEqual(true, buildingPredefined.hasAppearance);
             Assert.AreEqual(0, buildingPredefined.minLOD);
-            Assert.AreEqual(3, buildingPredefined.maxLOD);
+            Assert.AreEqual(4, buildingPredefined.maxLOD);
         }
     }
 }

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/DatasetAccessorTest.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/DatasetAccessorTest.cs
@@ -31,8 +31,8 @@ namespace PLATEAU.Test.Dataset
             using var source = DatasetSource.CreateForMockServer(TestDatasetIdServer);
             using var accessor = source.Accessor;
             var meshCodes = accessor.MeshCodes;
-            Assert.AreEqual(2, meshCodes.Length);
-            Assert.AreEqual("53392670", meshCodes.At(1).ToString());
+            Assert.AreEqual(3, meshCodes.Length);
+            Assert.AreEqual("53392642", meshCodes.At(1).ToString());
         }
         
         [TestMethod]
@@ -77,7 +77,7 @@ namespace PLATEAU.Test.Dataset
             using var accessor = source.Accessor;
             var buildings = accessor.GetGmlFiles(PredefinedCityModelPackage.Building);
             Assert.AreEqual(2, buildings.Length);
-            var expected = PredefinedCityModelPackage.Building | PredefinedCityModelPackage.Road | PredefinedCityModelPackage.UrbanPlanningDecision | PredefinedCityModelPackage.LandUse;
+            var expected = PredefinedCityModelPackage.Building | PredefinedCityModelPackage.Road | PredefinedCityModelPackage.UrbanPlanningDecision | PredefinedCityModelPackage.LandUse | PredefinedCityModelPackage.Relief;
             Assert.AreEqual(expected, accessor.Packages);
         }
         
@@ -166,7 +166,7 @@ namespace PLATEAU.Test.Dataset
             // ここでいう基準点とは、下のWebサイトにおける 9番の地点です。
             // https://www.gsi.go.jp/sokuchikijun/jpc.html
             Assert.IsTrue(Math.Abs(center.Z - (-51000)) < 2000, "南に51km"); // Local と Server で値がちょっと違うので2kmの誤差猶予を持たせます。
-            Assert.IsTrue(Math.Abs(center.X - (-9000)) < 4000, "西に9km");
+            Assert.IsTrue(Math.Abs(center.X - (-9000)) < 5000, "西に9km");
         }
         
         

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/DatasetSourceTest.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Dataset/DatasetSourceTest.cs
@@ -20,7 +20,7 @@ namespace PLATEAU.Test.Dataset
         {
             using var source = DatasetSource.CreateForMockServer("23ku");
             using var accessor = source.Accessor;
-            Assert.AreEqual("53392670", accessor.MeshCodes.At(1).ToString());
+            Assert.AreEqual("53392642", accessor.MeshCodes.At(1).ToString());
             var gmls = accessor.GetGmlFiles(PredefinedCityModelPackage.Building);
             Assert.AreEqual(
                 NetworkConfig.MockServerUrl + "/13100_tokyo23-ku_2020_citygml_3_2_op/udx/bldg/53392642_bldg_6697_2_op.gml",
@@ -28,7 +28,8 @@ namespace PLATEAU.Test.Dataset
             var expectedPackages =
                 PredefinedCityModelPackage.Building | PredefinedCityModelPackage.Road |
                 PredefinedCityModelPackage.LandUse |
-                PredefinedCityModelPackage.UrbanPlanningDecision;
+                PredefinedCityModelPackage.UrbanPlanningDecision |
+                PredefinedCityModelPackage.Relief;
             Assert.AreEqual(expectedPackages, accessor.Packages);
         }
     }


### PR DESCRIPTION


## 実装内容
- GMLファイルの中身が少ない時に最大LODを正しく取得できないバグを修正し、ユニットテスト追加
- CIのWindows & Visual Studio を 2019 から 2022 へ変更するよう、github actions とドキュメントを変更しました。
- 少し前からユニットテストが失敗したいたのを修正しました。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [x] 自動ビルド・テストが通っていること
- [x] Squash and Mergeが選択されていること
- [x] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
ユニットテストが通ります

