### PR TITLE
Feature/city object list

### DIFF
--- a/include/plateau/polygon_mesh/city_object_list.h
+++ b/include/plateau/polygon_mesh/city_object_list.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <libplateau_api.h>
+#include <map>
+
+namespace plateau::polygonMesh {
+
+
+    struct CityObjectIndex {
+        TVec2f vec;
+
+        //コンストラクタ
+        CityObjectIndex(TVec2f _vec) : vec(_vec) {
+        }
+
+        TVec2f getUV() {
+            return(vec);
+        }
+
+        CityObjectIndex(int primaryNum, int atomicNum) {
+            vec = TVec2f(primaryNum, atomicNum);
+        }
+
+        // `std::map` のキーとして `Node` オブジェクトを使用するための `<` 演算子をオーバーロードする
+        //現在のオブジェクトが指定されたオブジェクトの前にある場合はtrueを返します
+        bool operator<(const CityObjectIndex& obj) const {
+            //return (obj.vec.x < obj.vec.y) ? true : (obj.vec.x == obj.vec.y) ? ((obj.vec.x < obj.vec.y) ? true : false) : false;
+            return (obj.vec.x < obj.vec.y);
+        }
+    };
+
+
+    /**
+     * CityObjectListは、地物インデックスと地物IDの対応関係を保持するために、Modelに含まれる地物のリストを保持する目的で設計されています。
+     * 
+     * plateau::polygonMesh::Modelに次のメンバー変数を追加します。
+     * 上記のUVに記録したID ( CityObjectIndex ) と、 gml:id を対応付けるデータ構造  CityObjectListを作成します。
+     * CityObjectListは、 std::map<CityObjectIndex, std::string> city_object_index_to_gml_idから構成されます。
+     * なお、std::map のキーに自作の構造体をとるには、比較演算子< を定義する必要があることに注意してください。
+     * 参考: 逆引き！ C++でMapのキーとして、自分で定義した構造体を利用する
+     * 「https://programming-tips.info/use_struct_as_key_of_map/cpp/index.html」
+     *
+     * mesh_extractor の処理において、上記の city_object_indexが構築されるようにし、ゲームエンジンから読めるようにしてください。
+     * 
+     * ■ メンバー関数
+     * 
+     * std::string& getAtomicGmlId(CityObjectIndexType cityObjectIndex)
+     * std::string& getPrimaryGmlId(int id)
+     * 
+     * 主要地物のCityObjectIndexは、(n, -1)ですが、内部的な「-1」を隠匿するために
+     * getAtomicGmlId()とgetPrimaryGmlId()を使い分けます。
+     * 
+     */
+    class LIBPLATEAU_EXPORT CityObjectList {
+
+    public:
+        CityObjectList();
+
+    public:
+        CityObjectIndex createtPrimaryId();
+        CityObjectIndex createtAtomicId();
+        //CityObjectIndex createtPrimaryCityObjectIndex(int index);
+
+    public:
+        const std::string& getAtomicGmlId(CityObjectIndex CityObjectIndex);
+        const std::string& getPrimaryGmlId(int id);
+
+    public:
+        void add(CityObjectIndex key, std::string value);
+
+    private:
+        const int none = -1;
+        int primary_id = 0;
+        int atomic_id = 0;
+        std::map<CityObjectIndex, std::string> city_object_index_to_gml_id;
+
+    };
+
+}

--- a/include/plateau/polygon_mesh/mesh.h
+++ b/include/plateau/polygon_mesh/mesh.h
@@ -4,6 +4,7 @@
 #include "sub_mesh.h"
 #include "mesh_extract_options.h"
 #include "citygml/cityobject.h"
+#include "plateau/polygon_mesh/city_object_list.h"
 #include <libplateau_api.h>
 #include <optional>
 
@@ -46,6 +47,7 @@ namespace plateau::polygonMesh {
         const UV& getUV1() const;
         const UV& getUV2() const;
         const UV& getUV3() const;
+        const UV& getUV4() const;
         const std::vector<SubMesh>& getSubMeshes() const;
         void reserve(long long vertex_count);
 
@@ -58,6 +60,7 @@ namespace plateau::polygonMesh {
         void addUV1(const std::vector<TVec2f>& other_uv_1, unsigned long long other_vertices_size);
         void addUV2WithSameVal(const TVec2f& uv_2_val, unsigned num_adding_vertices);
         void addUV3WithSameVal(const TVec2f& uv_3_val, unsigned num_adding_vertices);
+        void addUV4WithSameVal(const TVec2f& uv_4_val, unsigned num_adding_vertices);
 
         /**
          * SubMesh を追加し、そのテクスチャパスには 引数のものを指定します。
@@ -80,12 +83,16 @@ namespace plateau::polygonMesh {
 
         /// メッシュとサブメッシュに関する情報を stringstream に書き込みます。
         void debugString(std::stringstream& ss, int indent) const;
+
+        CityObjectList GetCityObjectList() const;
+
     private:
         std::vector<TVec3d> vertices_;
         std::vector<unsigned> indices_;
         UV uv1_;
         UV uv2_;
         UV uv3_;
+        UV uv4_;
         std::vector<SubMesh> sub_meshes_;
     };
 }

--- a/include/plateau/polygon_mesh/mesh_merger.h
+++ b/include/plateau/polygon_mesh/mesh_merger.h
@@ -42,14 +42,28 @@ namespace plateau::polygonMesh {
                                   plateau::geometry::CoordinateSystem mesh_axis_convert_to, bool include_texture);
 
         /**
-         * merge関数を 引数 city_object_ の各 Polygon に対して実行します。
+         * 最小地物のMeshのuv4フィールドに主要地物IDを設定しMeshをマージします。
          */
-        static void mergePolygonsInCityObject(Mesh& mesh, const citygml::CityObject& city_object, unsigned int lod,
+        static void mergePolygonsInPrimaryCityObject(Mesh& mesh, const citygml::CityObject& city_object, unsigned int lod,
                                               const MeshExtractOptions& mesh_extract_options, const geometry::GeoReference& geo_reference,
                                               const TVec2f& uv_2_element, const TVec2f& uv_3_element, const std::string& gml_path);
 
         /**
-         * merge関数を 引数 city_objects の 各 CityObject の 各 Polygon に対して実行します。
+         * 最小地物のMeshのuv4フィールドに最小地物IDを設定しMeshをマージします。
+         */
+        static void mergePolygonsInAtomicCityObject(Mesh& mesh, const citygml::CityObject& city_object, unsigned int lod,
+                                              const MeshExtractOptions& mesh_extract_options, const geometry::GeoReference& geo_reference,
+                                              const TVec2f& uv_2_element, const TVec2f& uv_3_element, const std::string& gml_path);
+
+        /**
+         * 最小地物のMeshのuv4フィールドに最小地物IDを設定するために、最小地物を構成するPolygonに含まれるVertex数を取得します。
+         */
+        static int checkPolygonsInAtomicCityObject(Mesh& mesh, const citygml::CityObject& city_object, unsigned int lod,
+                                              const MeshExtractOptions& mesh_extract_options, const geometry::GeoReference& geo_reference,
+                                              const TVec2f& uv_2_element, const TVec2f& uv_3_element, const std::string& gml_path);
+
+        /**
+         * 主要地物のMeshのuv4フィールドに、主要地物のcity_objectsに含まれるすべての最小地物の最小地物IDを設定しMeshをマージします。
          */
         static void
         mergePolygonsInCityObjects(Mesh& mesh, const std::list<const citygml::CityObject*>& city_objects, unsigned int lod,

--- a/src/polygon_mesh/CMakeLists.txt
+++ b/src/polygon_mesh/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(plateau PRIVATE
         "grid_merger.cpp"
         "polygon_mesh_utils.cpp"
         "mesh_merger.cpp"
+	    "city_object_list.cpp"
 )

--- a/src/polygon_mesh/city_object_list.cpp
+++ b/src/polygon_mesh/city_object_list.cpp
@@ -1,0 +1,36 @@
+#include <plateau/polygon_mesh/node.h>
+#include "plateau/polygon_mesh/city_object_list.h"
+#include <algorithm>
+#include <string>
+#include <cassert>
+
+namespace plateau::polygonMesh {
+
+    CityObjectList::CityObjectList() {
+        auto size = city_object_index_to_gml_id.max_size();
+    }
+
+    static std::map<CityObjectIndex, std::string, std::less<>> feature_index_to_gml_id;
+
+    CityObjectIndex CityObjectList::createtPrimaryId() {
+        atomic_id = 0;
+        return(CityObjectIndex(primary_id++, none));
+    }
+
+    CityObjectIndex CityObjectList::createtAtomicId() {
+        return(CityObjectIndex(primary_id, atomic_id++));
+    }
+
+    const std::string& CityObjectList::getAtomicGmlId(CityObjectIndex featureIndex) {
+        return(feature_index_to_gml_id[featureIndex]);
+    }
+
+    const std::string& CityObjectList::getPrimaryGmlId(int id) {
+        return(feature_index_to_gml_id[CityObjectIndex(id, none)]);
+    }
+
+    void CityObjectList::add(CityObjectIndex key, std::string value) {
+        
+        feature_index_to_gml_id[key] = value;
+    }
+}

--- a/src/polygon_mesh/grid_merger.cpp
+++ b/src/polygon_mesh/grid_merger.cpp
@@ -180,6 +180,9 @@ namespace plateau::polygonMesh {
             const auto& group_objs = group.second;
             // グループ内でマージする Mesh の新規作成
             Mesh group_mesh;
+
+            auto CityObjectList = group_mesh.GetCityObjectList();
+
             // グループ内の各オブジェクトのループ
             for (const auto& city_obj: group_objs) {
                 long long city_obj_vertex_count = 0;
@@ -194,6 +197,15 @@ namespace plateau::polygonMesh {
                     MeshMerger::mergePolygon(group_mesh, *poly, options, geo_reference, uv_2, uv_3,
                                              city_model.getGmlPath());
                 }
+
+                auto AtomicId = CityObjectList.createtAtomicId();
+                auto GmlId = city_obj.getCityObject()->getId();
+
+                if (city_obj_vertex_count > 0) {
+                    group_mesh.addUV4WithSameVal(AtomicId.getUV(), city_obj_vertex_count);
+                }
+
+                CityObjectList.add(AtomicId, GmlId);
             }
             merged_meshes.emplace(group_id, std::move(group_mesh));
         }

--- a/src/polygon_mesh/mesh.cpp
+++ b/src/polygon_mesh/mesh.cpp
@@ -9,11 +9,14 @@
 namespace plateau::polygonMesh {
     using namespace citygml;
 
+    CityObjectList root_city_object_list;
+
     Mesh::Mesh() :
             vertices_(),
             uv1_(UV()),
             uv2_(UV()),
             uv3_(UV()),
+            uv4_(UV()),
             sub_meshes_() {
     }
 
@@ -24,6 +27,7 @@ namespace plateau::polygonMesh {
         uv1_ = uv_1;
         uv2_ = UV();
         uv3_ = UV();
+        uv4_ = UV();
         auto vertices_count = vertices_.size();
         uv2_.reserve(vertices_count);
         uv3_.reserve(vertices_count);
@@ -65,6 +69,10 @@ namespace plateau::polygonMesh {
         return uv3_;
     }
 
+    const UV& Mesh::getUV4() const {
+        return uv4_;
+    }
+
     const std::vector<SubMesh>& Mesh::getSubMeshes() const {
         return sub_meshes_;
     }
@@ -75,6 +83,7 @@ namespace plateau::polygonMesh {
         uv1_.reserve(vertex_count);
         uv2_.reserve(vertex_count);
         uv3_.reserve(vertex_count);
+        uv4_.reserve(vertex_count);
     }
 
     void Mesh::addVerticesList(const std::vector<TVec3d>& other_vertices) {
@@ -145,6 +154,12 @@ namespace plateau::polygonMesh {
         }
     }
 
+    void Mesh::addUV4WithSameVal(const TVec2f& uv_4_val, unsigned num_adding_vertices) {
+        for (int i = 0; i < num_adding_vertices; i++) {
+            uv4_.push_back(uv_4_val);
+        }
+    }
+
     void Mesh::addSubMesh(const std::string& texture_path, size_t sub_mesh_start_index, size_t sub_mesh_end_index) {
         // テクスチャが異なる場合は追加します。
         // TODO テクスチャありのポリゴン と なしのポリゴン が交互にマージされることで、テクスチャなしのサブメッシュが大量に生成されるので描画負荷に改善の余地ありです。
@@ -182,5 +197,9 @@ namespace plateau::polygonMesh {
         for (const auto& sub_mesh: sub_meshes_) {
             sub_mesh.debugString(ss, indent + 1);
         }
+    }
+
+    CityObjectList Mesh::GetCityObjectList() const {
+        return(root_city_object_list);
     }
 }

--- a/src/polygon_mesh/mesh_extractor.cpp
+++ b/src/polygon_mesh/mesh_extractor.cpp
@@ -53,9 +53,16 @@ namespace plateau::polygonMesh {
                             // 範囲外ならスキップします。
                             if (shouldSkipCityObj(*primary_obj, options)) continue;
                             // 主要地物のメッシュを作ります。
+
                             Mesh mesh;
+
+                            auto ObjectCityList = mesh.GetCityObjectList();
+                            auto PrimaryId = ObjectCityList.createtPrimaryId();
+                            auto GmlId = primary_obj->getId();
+                            ObjectCityList.add(PrimaryId, GmlId);
+
                             if (MeshExtractor::shouldContainPrimaryMesh(lod, *primary_obj)) {
-                                MeshMerger::mergePolygonsInCityObject(mesh, *primary_obj, lod, options, geo_reference,
+                                MeshMerger::mergePolygonsInPrimaryCityObject(mesh, *primary_obj, lod, options, geo_reference,
                                                                       TVec2f{0, 0},
                                                                       TVec2f{0, 0}, city_model.getGmlPath());
                             }
@@ -84,7 +91,7 @@ namespace plateau::polygonMesh {
 
                             if (MeshExtractor::shouldContainPrimaryMesh(lod, *primary_obj)) {
                                 primary_mesh = Mesh();
-                                MeshMerger::mergePolygonsInCityObject(primary_mesh.value(), *primary_obj, lod, options,
+                                MeshMerger::mergePolygonsInPrimaryCityObject(primary_mesh.value(), *primary_obj, lod, options,
                                                                       geo_reference,
                                                                       TVec2f{0, 0},
                                                                       TVec2f{0, 0}, city_model.getGmlPath());
@@ -95,7 +102,7 @@ namespace plateau::polygonMesh {
                             for (auto atomic_obj: atomic_objs) {
                                 // 最小地物のノードを作成
                                 auto atomic_mesh = Mesh();
-                                MeshMerger::mergePolygonsInCityObject(atomic_mesh, *atomic_obj, lod, options,
+                                MeshMerger::mergePolygonsInAtomicCityObject(atomic_mesh, *atomic_obj, lod, options,
                                                                       geo_reference,
                                                                       TVec2f{0, 0},
                                                                       TVec2f{0, 0}, city_model.getGmlPath());


### PR DESCRIPTION

## 実装内容
■ 地物インデックス（主要地物、最小地物）と、地物IDの対応関係を保持するために、
　「CityObjectList」クラスの追加。

■ Meshクラスに「uv4」フィールドを追加し、地物インデックス（主要地物、最小地物）
　を格納できるように変更。

■ 各Meshクラス内に、「CityObjectList」インスタンスを保持するように変更。

■ メッシュの結合単位の中で、都市モデル地域単位(GMLファイル内のすべてを結合)
　する「PerCityModelArea」処理に対応するために、「grid_merger.cpp」内の
　メソッドの更新。

　□ gridMerge関数
　　結合後のMeshのuv4フィールドに主要地物ID、最小地物IDを設定しMeshをマージします。

■ Meshクラスの「uv4」フィールドに、地物インデックス（主要地物、最小地物）を
　格納するために、「mesh_merger.cpp」の各種メソッドの更新。

　□ mergePolygonsInPrimaryCityObject関数
　　最小地物のMeshのuv4フィールドに主要地物IDを設定しMeshをマージします。

　□ mergePolygonsInAtomicCityObject関数
　　最小地物のMeshのuv4フィールドに最小地物IDを設定しMeshをマージします。

　□ checkPolygonsInAtomicCityObject関数
　　最小地物のMeshのuv4フィールドに最小地物IDを設定するために、
　　最小地物を構成するPolygonに含まれるVertex数を取得します。

　□ mergePolygonsInCityObjects関数
　　主要地物のMeshのuv4フィールドに、主要地物のcity_objectsに含まれる
　　すべての最小地物の最小地物IDを設定しMeshをマージします。

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
