### PR TITLE
Upload-Dllでarm64向けにビルドされない問題の修正

### DIFF
--- a/.github/actions/upload-dll/action.yml
+++ b/.github/actions/upload-dll/action.yml
@@ -26,6 +26,7 @@ runs:
       with:
         shell_type: ${{ inputs.shell_type }}
         visual_studio_version: ${{ inputs.visual_studio_version }}
+        arch: ${{ inputs.arch }}
 
     - name: Copy DLL for Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
## 実装内容
upload-dll.yamlでbuild-and-testのarch引数が渡されていなかったため修正した。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [x] 自動ビルド・テストが通っていること
- [x] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
