### PR TITLE
分割結合で、gmlファイルを複数選んで主要→地域に変換するとバグるのを修正

### DIFF
--- a/include/plateau/granularity_convert/node_stack.h
+++ b/include/plateau/granularity_convert/node_stack.h
@@ -19,7 +19,8 @@ namespace plateau::granularityConvert {
 
         /// 引数で与えられたモデルの各ルートノードをキューに追加します。
         void pushRoot(const plateau::polygonMesh::Model* model) {
-            for(int i=0; i<model->getRootNodeCount(); i++) {
+            // indexの小さい方から処理したいので、stackには逆順に積みます。
+            for(int i=model->getRootNodeCount() - 1; i>=0; i--) {
                 push(NodePath({i}));
             }
         }

--- a/test/test_granularity_convert/model_convert_test_patterns.cpp
+++ b/test/test_granularity_convert/model_convert_test_patterns.cpp
@@ -183,7 +183,173 @@ ModelConvertTestPatterns ModelConvertTestPatternsFactory::createTestPatternsOfAt
     adjustForTestModelForAtomic(atomic_model);
     auto expects = area_patterns.getExpects();
     auto& expect_primary = expects.at(MeshGranularity::PerPrimaryFeatureObject);
+
     return {std::move(atomic_model), expects};
+}
+
+ModelConvertTestPatterns ModelConvertTestPatternsFactory::createTestPatternsOfArea_MultipleGMLs() {
+    auto model = Model();
+    auto& gml1 = model.addNode(Node("gml1"));
+    auto& lod1 = gml1.addChildNode(Node("lod1"));
+    auto mesh1 = createTestMeshOfArea(test_indices_primary_and_atomic, test_city_obj_list_primary_and_atomic);
+    auto& mesh1_node = lod1.addChildNode(Node("mesh1"));
+    auto& gml2 = model.addNode(Node("gml2"));
+    auto& lod2 = gml2.addChildNode(Node("lod2"));
+    auto& mesh2_node = lod2.addChildNode(Node("mesh2"));
+    auto mesh2 = createTestMeshOfArea(test_indices_primary_and_atomic, test_city_obj_list_primary_and_atomic);
+    mesh1_node.setMesh(std::move(mesh1));
+    mesh2_node.setMesh(std::move(mesh2));
+
+    auto atomic_expect = ModelExpect(std::vector<NodeExpect>{
+        NodeExpect("gml1", false, 0, {}, {}, {}),
+        NodeExpect("gml2", false, 0, {}, {}, {}),
+        NodeExpect("lod1", false, 0, {}, {}, {}),
+        NodeExpect("lod2", false, 0, {}, {}, {}),
+        NodeExpect("primary-0", true, 4,
+                   {{{0, -1}}},
+                   {{{{0, -1}, "primary-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_0", nullptr)}),
+        NodeExpect("primary-1", true, 4,
+                   {{{0, -1}}},
+                   {{{{0, -1}, "primary-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_5", nullptr)}),
+        NodeExpect("primary-0", true, 4,
+                   {{{0, -1}}},
+                   {{{{0, -1}, "primary-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_0", nullptr)}),
+        NodeExpect("primary-1", true, 4,
+                   {{{0, -1}}},
+                   {{{{0, -1}, "primary-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_5", nullptr)}),
+        NodeExpect("atomic-0-0", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_1", nullptr)}),
+        NodeExpect("atomic-0-1", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_2", nullptr)}),
+        NodeExpect("atomic-1-0", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_3", nullptr)}),
+        NodeExpect("atomic-1-1", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_4", nullptr)}),
+        NodeExpect("atomic-0-0", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_1", nullptr)}),
+        NodeExpect("atomic-0-1", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_2", nullptr)}),
+        NodeExpect("atomic-1-0", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-0"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_3", nullptr)}),
+        NodeExpect("atomic-1-1", true, 4,
+                   {{{0, 0}}},
+                   {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-1"}}},
+                   {SubMesh(0, 5, "dummy_tex_path_4", nullptr)})
+    });
+
+    auto primary_expect = ModelExpect(std::vector<NodeExpect>{
+            NodeExpect("gml1", false, 0, {}, {}, {}),
+            NodeExpect("gml2", false, 0, {}, {}, {}),
+            NodeExpect("lod1", false, 0, {}, {}, {}),
+            NodeExpect("lod2", false, 0, {}, {}, {}),
+            NodeExpect("primary-0", true, 4 * 3, {{{0, -1}, {0, 0}, {0, 1}}},
+                       {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-0"}, {{0, 1}, "atomic-0-1"}}},
+                       {SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                        SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                        SubMesh(12, 17, "dummy_tex_path_2", nullptr)
+                       }),
+            NodeExpect("primary-1", true, 4 * 3, {{{0, -1}, {0, 0}, {0, 1}}},
+                       {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-0"}, {{0, 1}, "atomic-1-1"}}},
+                       {SubMesh(0, 5, "dummy_tex_path_5", nullptr),
+                        SubMesh(6, 11, "dummy_tex_path_3", nullptr),
+                        SubMesh(12, 17, "dummy_tex_path_4", nullptr)}),
+            // 2つ目
+            NodeExpect("primary-0", true, 4 * 3, {{{0, -1}, {0, 0}, {0, 1}}},
+                       {{{{0, -1}, "primary-0"}, {{0, 0}, "atomic-0-0"}, {{0, 1}, "atomic-0-1"}}},
+                       {SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                        SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                        SubMesh(12, 17, "dummy_tex_path_2", nullptr)
+                       }),
+            NodeExpect("primary-1", true, 4 * 3, {{{0, -1}, {0, 0}, {0, 1}}},
+                       {{{{0, -1}, "primary-1"}, {{0, 0}, "atomic-1-0"}, {{0, 1}, "atomic-1-1"}}},
+                       {SubMesh(0, 5, "dummy_tex_path_5", nullptr),
+                        SubMesh(6, 11, "dummy_tex_path_3", nullptr),
+                        SubMesh(12, 17, "dummy_tex_path_4", nullptr)})
+    });
+
+    auto area_expect = ModelExpect(std::vector<NodeExpect>{
+            NodeExpect("gml1", false, 0, {}, {}, {}),
+            NodeExpect("gml2", false, 0, {}, {}, {}),
+            NodeExpect("lod1", false, 0, {}, {}, {}),
+            NodeExpect("lod2", false, 0, {}, {}, {}),
+            NodeExpect("combined", true, 4 * 6,
+                       {{
+                                {0, -1},
+                                {0, 0},
+                                {0, 1},
+                                {1, -1},
+                                {1, 0},
+                                {1, 1}
+                        }},
+                       {{
+                                {{0, -1}, "primary-0"},
+                                {{0, 0}, "atomic-0-0"},
+                                {{0, 1}, "atomic-0-1"},
+                                {{1, -1}, "primary-1"},
+                                {{1, 0}, "atomic-1-0"},
+                                {{1, 1}, "atomic-1-1"}
+                        }},
+                       {
+                               SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                               SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                               SubMesh(12, 17, "dummy_tex_path_2", nullptr),
+                               SubMesh(18, 23, "dummy_tex_path_5", nullptr),
+                               SubMesh(24, 29, "dummy_tex_path_3", nullptr),
+                               SubMesh(30, 35, "dummy_tex_path_4", nullptr)
+                       }
+            ),
+            // 2つ目
+            NodeExpect("combined", true, 4 * 6,
+                       {{
+                                {0, -1},
+                                {0, 0},
+                                {0, 1},
+                                {1, -1},
+                                {1, 0},
+                                {1, 1}
+                        }},
+                       {{
+                                {{0, -1}, "primary-0"},
+                                {{0, 0}, "atomic-0-0"},
+                                {{0, 1}, "atomic-0-1"},
+                                {{1, -1}, "primary-1"},
+                                {{1, 0}, "atomic-1-0"},
+                                {{1, 1}, "atomic-1-1"}
+                        }},
+                       {
+                               SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                               SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                               SubMesh(12, 17, "dummy_tex_path_2", nullptr),
+                               SubMesh(18, 23, "dummy_tex_path_5", nullptr),
+                               SubMesh(24, 29, "dummy_tex_path_3", nullptr),
+                               SubMesh(30, 35, "dummy_tex_path_4", nullptr)
+                       })
+
+    });
+    ModelConvertTestPatterns::TGranularityToExpect expects = {
+            {MeshGranularity::PerAtomicFeatureObject, atomic_expect},
+            {MeshGranularity::PerPrimaryFeatureObject, primary_expect},
+            {MeshGranularity::PerCityModelArea, area_expect}
+    };
+    return {std::move(model), expects};
 }
 
 ModelConvertTestPatterns ModelConvertTestPatternsFactory::createTestPatternsOfPrimary_OnlyAtomicMesh() {

--- a/test/test_granularity_convert/model_convert_test_patterns.cpp
+++ b/test/test_granularity_convert/model_convert_test_patterns.cpp
@@ -140,20 +140,20 @@ ModelConvertTestPatterns ModelConvertTestPatternsFactory::createTestPatternsOfAr
     expects_to_area.eraseRange(0, 2);
     expects_to_area.at(0).expect_node_name_ = "combined";
     expects_to_area.at(0).expect_city_obj_list_ =
-            {{{{0, -1}, "primary-1"},
-              {{0, 0}, "atomic-1-0"},
-              {{0, 1}, "atomic-1-1"},
-              {{1, -1}, "primary-0"},
-              {{1, 0}, "atomic-0-0"},
-              {{1, 1}, "atomic-0-1"}}};
+            {{{{0, -1}, "primary-0"},
+              {{0, 0}, "atomic-0-0"},
+              {{0, 1}, "atomic-0-1"},
+              {{1, -1}, "primary-1"},
+              {{1, 0}, "atomic-1-0"},
+              {{1, 1}, "atomic-1-1"}}};
     expects_to_area.at(0).expect_sub_meshes_ =
             {
-                    SubMesh(0, 5, "dummy_tex_path_5", nullptr),
-                    SubMesh(6, 11, "dummy_tex_path_3", nullptr),
-                    SubMesh(12, 17, "dummy_tex_path_4", nullptr),
-                    SubMesh(18, 23, "dummy_tex_path_0", nullptr),
-                    SubMesh(24, 29, "dummy_tex_path_1", nullptr),
-                    SubMesh(30, 35, "dummy_tex_path_2", nullptr)
+                    SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                    SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                    SubMesh(12, 17, "dummy_tex_path_2", nullptr),
+                    SubMesh(18, 23, "dummy_tex_path_5", nullptr),
+                    SubMesh(24, 29, "dummy_tex_path_3", nullptr),
+                    SubMesh(30, 35, "dummy_tex_path_4", nullptr)
             };
 
 
@@ -385,18 +385,18 @@ ModelConvertTestPatterns ModelConvertTestPatternsFactory::createTestPatternsOfAr
                                                     {1, 0},
                                                     {1, 1}};
     expect_to_area.at(0).expect_city_obj_list_ =
-            {{{{0, -1}, "primary-1"},
-              {{0, 0}, "atomic-1-0"},
-              {{0, 1}, "atomic-1-1"},
-              {{1, -1}, "primary-0"},
-              {{1, 0}, "atomic-0-0"},
-              {{1, 1}, "atomic-0-1"}}};
+            {{{{0, -1}, "primary-0"},
+              {{0, 0}, "atomic-0-0"},
+              {{0, 1}, "atomic-0-1"},
+              {{1, -1}, "primary-1"},
+              {{1, 0}, "atomic-1-0"},
+              {{1, 1}, "atomic-1-1"}}};
     expect_to_area.at(0).expect_sub_meshes_ =
             {
-                    SubMesh(0, 5, "dummy_tex_path_2", nullptr),
-                    SubMesh(6, 11, "dummy_tex_path_3", nullptr),
-                    SubMesh(12, 17, "dummy_tex_path_0", nullptr),
-                    SubMesh(18, 23, "dummy_tex_path_1", nullptr)
+                    SubMesh(0, 5, "dummy_tex_path_0", nullptr),
+                    SubMesh(6, 11, "dummy_tex_path_1", nullptr),
+                    SubMesh(12, 17, "dummy_tex_path_2", nullptr),
+                    SubMesh(18, 23, "dummy_tex_path_3", nullptr)
             };
 
     return {std::move(model), expects};

--- a/test/test_granularity_convert/model_convert_test_patterns.h
+++ b/test/test_granularity_convert/model_convert_test_patterns.h
@@ -102,6 +102,8 @@ public:
     ModelConvertTestPatterns createTestPatternsOfPrimary_OnlyRoot();
     ModelConvertTestPatterns createTestPatternsOfAtomic_OnlyRoot();
 
+    ModelConvertTestPatterns createTestPatternsOfArea_MultipleGMLs();
+
     /// テスト用モデル（地域単位）で、主要地物のメッシュがないバージョンです。
     ModelConvertTestPatterns createTestPatternsFromArea_OnlyAtomicMesh();
     /// テスト（主要地物）

--- a/test/test_granularity_convert/test_granularity_converter.cpp
+++ b/test/test_granularity_convert/test_granularity_converter.cpp
@@ -56,6 +56,17 @@ TEST_F(GranularityConverterTest, convertAtomicToArea_OnlyRoot) { // NOLINT
     ModelConvertTestPatternsFactory().createTestPatternsOfAtomic_OnlyRoot().test(MeshGranularity::PerCityModelArea);
 }
 
+TEST_F(GranularityConverterTest, convertAreaToAtomic_MultipleGMLs) { // NOLINT
+    ModelConvertTestPatternsFactory().createTestPatternsOfArea_MultipleGMLs().test(MeshGranularity::PerAtomicFeatureObject);
+}
+
+TEST_F(GranularityConverterTest, convertAreaToPrimary_MultipleGMLs) { // NOLINT
+    ModelConvertTestPatternsFactory().createTestPatternsOfArea_MultipleGMLs().test(MeshGranularity::PerPrimaryFeatureObject);
+}
+
+TEST_F(GranularityConverterTest, convertAreaToArea_MultipleGMLs) { // NOLINT
+    ModelConvertTestPatternsFactory().createTestPatternsOfArea_MultipleGMLs().test(MeshGranularity::PerCityModelArea);
+}
 
 TEST_F(GranularityConverterTest, convertAtomicToArea) { // NOLINT
     ModelConvertTestPatternsFactory().createTestPatternsOfAtomic().test(MeshGranularity::PerCityModelArea);

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/MeshCode.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/MeshCode.cs
@@ -90,6 +90,12 @@ namespace PLATEAU.Dataset
             return $"{this.FirstRow | 00}{this.FirstCol | 00}{this.SecondRow | 0}{this.SecondCol | 0}";
         }
 
+        public string Level3()
+        {
+            ThrowIfInvalid();
+            return $"{Level2()}{this.ThirdRow | 0}{this.ThirdCol | 0}";
+        }
+
         private void ThrowIfInvalid()
         {
             if (IsValid) return;

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Native/Extent.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Native/Extent.cs
@@ -27,13 +27,14 @@ namespace PLATEAU.Native
         /// <summary>
         /// 共通部分を返します。
         /// なければ (-99, -99, -99), (-99, -99, -99)を返します。
+        /// 高さを考慮しない場合は、ignoreHeightをtrueにします。
         /// </summary>
-        public static Extent Intersection(Extent op1, Extent op2)
+        public static Extent Intersection(Extent op1, Extent op2, bool ignoreHeight = false)
         {
             var max = GeoCoordinate.Max(op1.Max, op2.Max);
             var min = GeoCoordinate.Min(op1.Min, op2.Min);
             var intersectSize = op1.Size() + op2.Size() - (max - min);
-            if (intersectSize.Latitude <= 0 || intersectSize.Latitude <= 0 || intersectSize.Height <= 0)
+            if (intersectSize.Latitude <= 0 || intersectSize.Latitude <= 0 || (!ignoreHeight && intersectSize.Height <= 0))
                 return new Extent(new GeoCoordinate(-99,-99,-99), new GeoCoordinate(-99, -99, -99));
             var minMax = GeoCoordinate.Min(op1.Max, op2.Max);
             var maxMin = GeoCoordinate.Max(op1.Min, op2.Min);


### PR DESCRIPTION


## 実装内容
- 分割結合で、gmlファイルを複数選んで主要→地域に変換すると結果がおかしい問題を修正しました。

## レビュー前確認項目
- [x] 自動ビルド・テストが通っていること

## マージ前確認項目
- [x] 自動ビルド・テストが通っていること
- [x] Squash and Mergeが選択されていること
- [x] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
- Unityで確認できます
- ユニットテストで確認できます
