### PR TITLE
LOD検索機能で、仕様上最大のLODが見つかったら早期returnすることで高速化

### DIFF
--- a/include/plateau/dataset/lod_searcher.h
+++ b/include/plateau/dataset/lod_searcher.h
@@ -13,26 +13,9 @@ namespace plateau::dataset {
      */
     class LIBPLATEAU_EXPORT LodSearcher {
     public:
-        static plateau::dataset::LodFlag searchLodsInFile(const std::filesystem::path& file_path);
-        static plateau::dataset::LodFlag searchLodsInIstream(std::istream& ifs);
-    };
-
-    /// どのLODが含まれるかをフラグ(unsigned)で表現します。
-    struct LIBPLATEAU_EXPORT LodFlag {
-    public:
-        /// 下から n ビット目を1にします。
-        void setFlag(unsigned digit);
-        /// 下から n ビット目を0にします。
-        void unsetFlag(unsigned digit);
-        unsigned getFlag() const;
-        /// 立っているフラグのうちもっとも上位のものが何ビット目かを返します。
-        /// フラグがどれも0なら-1を返します。
-        int getMax() const;
-        /// searchLodsInFile の実装の都合上、LODは1桁とします。
-        static const int max_lod_ = 9;
-
-    private:
-        /// lod n が含まれるとき、flags の下から n ビット目が立ちます。
-        unsigned flags_ = 0;
+        /// ファイル中に含まれる最大LODを返します。
+        /// 引数 specification_max_lod は仕様上とりうるLODの最大値であり、そのLODが見つかった場合は探索を終了してその値を返します。
+        static int searchMaxLodInFile(const std::filesystem::path& file_path, int specification_max_lod);
+        static int searchMaxLodInIstream(std::istream& ifs, int specification_max_lod);
     };
 }

--- a/src/dataset/gml_file.cpp
+++ b/src/dataset/gml_file.cpp
@@ -80,8 +80,8 @@ namespace plateau::dataset {
         if (isMaxLodCalculated())
             return max_lod_;
 
-        auto lods = LodSearcher::searchLodsInFile(fs::u8path(path_));
-        max_lod_ = lods.getMax();
+        int specification_max_lod = CityModelPackageInfo::getPredefined(getPackage()).maxLOD();
+        max_lod_ = LodSearcher::searchMaxLodInFile(fs::u8path(path_), specification_max_lod);
         if (max_lod_ < 0) max_lod_ = 0; // MaxLodが取得できなかった場合のフェイルセーフです。
         return max_lod_;
     }

--- a/test/test_lod_searcher.cpp
+++ b/test/test_lod_searcher.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <plateau/dataset/lod_searcher.h>
 #include <fstream>
+#include "plateau/dataset/city_model_package.h"
 
 namespace plateau::dataset {
     class LodSearcherTest : public ::testing::Test {
@@ -13,7 +14,7 @@ namespace plateau::dataset {
         int getMaxLod(const std::string& content) {
             auto string_buf = std::stringbuf(content);
             auto istream = std::istream(&string_buf);
-            return LodSearcher::searchLodsInIstream(istream).getMax();
+            return LodSearcher::searchMaxLodInIstream(istream, CityModelPackageInfo::getPredefined(PredefinedCityModelPackage::Building).maxLOD());
         }
     }
 


### PR DESCRIPTION


## 実装内容
Unityで伊豆氏の範囲選択画面を開くと、今まで土地のLODアイコンが出るのが非常に重かったのが実用的な速度になっているのを確認できます。

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```

<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
