### PR TITLE
地形への地図タイル結合後のファイル名が重複時に上書きしないようにしました

### DIFF
--- a/src/polygon_mesh/map_attacher.cpp
+++ b/src/polygon_mesh/map_attacher.cpp
@@ -114,9 +114,20 @@ namespace plateau::polygonMesh {
                     .parent_path()
                     .parent_path()
                     .parent_path();
-            std::string combined_file_name = "combined_map_for_mesh_" + std::to_string(i) + "_";
-            // TODO 下の ".png" の決め打ちはあまり良くない
-            const auto combined_image_path = fs::path(combined_tile_dir) / fs::u8path(combined_file_name + "0.png");
+
+            std::string combined_file_name;
+            fs::path combined_image_path;
+
+            // 同名のファイルがあったとき上書きしたくないので、同名でなくなるまでファイル名の番号を上げます
+            for(int attempt=0; attempt<999; attempt++){
+                // ファイル名は combined_map_mesh(mesh番号)_v(バージョン番号,基本は0だが同名のがすでにあれば増える)_p0 (pはpart、1枚にまとめるので基本0のはず)
+                combined_file_name = "combined_map_mesh" + std::to_string(i) + "_v" + std::to_string(attempt) + "_p";
+                // FIXME 下の ".png" の決め打ちはあまり良くない
+                combined_image_path = fs::path(combined_tile_dir) / fs::u8path(combined_file_name + "0.png");
+                if(!fs::exists(combined_image_path)){
+                    break;
+                }
+            }
             packer.setSaveFilePath(combined_tile_dir, combined_file_name);
             for (auto r = min_row; r <= max_row; r++) {
                 for (auto c = min_col; c <= max_col; c++) {

--- a/test/test_map_attacher.cpp
+++ b/test/test_map_attacher.cpp
@@ -48,6 +48,7 @@ TEST_F(MapAttacherTest, AttachGeneratesImageFiles) { // NOLINT
         const auto path = (fs::path(test_dir) / expect_file).make_preferred();
         EXPECT_TRUE(fs::exists(path)) << path.u8string() << " exists";
     }
+    EXPECT_TRUE(fs::exists(fs::u8path(u8"../data/日本語パステスト/test_map_attacher/combined_map_mesh0_v0_p0.png")));
     EXPECT_EQ(success_count, 4);
     fs::remove_all(test_dir);
 }


### PR DESCRIPTION

## 動作確認
Unityで地形を地図タイル付きでインポートを2回すると、
.PLATEAU/(dataset name)/udx/dem/(dem_gml_map)/combine_map_(xxx).png が2枚になっているのを確認できます

