### PR TITLE
竹芝LOD4を正しく検知できない問題を修正

### DIFF
--- a/include/plateau/dataset/lod_searcher.h
+++ b/include/plateau/dataset/lod_searcher.h
@@ -38,6 +38,8 @@ namespace plateau::dataset {
          * しかし、今後のあらゆるデータで大丈夫であるという保証はなく、今後に調整が必要になるかもしれません。
          */
         static constexpr std::streamsize max_gml_read_size_from_first_lod_found = 10 /*メガバイト*/*1000000;
+        static constexpr std::streamsize max_gml_read_size_from_second_lod_found = 60/*メガバイト*/*1000000; // LOD1→2を検索するときは多めに検索しないと見逃す
+        static constexpr std::streamsize max_gml_read_size_from_third_lod_found =  120/*メガバイト*/*1000000; // LOD3→4を検索するときはさらに多めに検索しないと見逃す
 //        static constexpr std::streamsize max_gml_read_size_from_first_lod_found = LONG_MAX;
     };
 }

--- a/src/dataset/lod_searcher.cpp
+++ b/src/dataset/lod_searcher.cpp
@@ -55,6 +55,8 @@ int LodSearcher::searchMaxLodInIstream(std::istream& ifs, int specification_max_
     const char* const chunk_const = chunk;
     int found_max_lod = -1;
     std::streamsize total_read_size_from_first_lod_found = 0;
+    std::streamsize total_read_size_from_second_lod_found = 0;
+    std::streamsize total_read_size_from_third_lod_found = 0;
 
     do {
         ifs.read(chunk, chunk_read_size);
@@ -85,7 +87,13 @@ int LodSearcher::searchMaxLodInIstream(std::istream& ifs, int specification_max_
 
         // 最初のLODが見つかってからここまで読めば十分という値に達したとき
         total_read_size_from_first_lod_found += (found_max_lod >= 0) ? read_size : 0;
-        if(total_read_size_from_first_lod_found > max_gml_read_size_from_first_lod_found) {
+        total_read_size_from_second_lod_found += (found_max_lod >= 2) ? read_size : 0;
+        total_read_size_from_third_lod_found += (found_max_lod >= 3) ? read_size : 0;
+        if (
+                total_read_size_from_first_lod_found > max_gml_read_size_from_first_lod_found &&
+                (found_max_lod < 2 || /* LOD2→3を探すとき*/ total_read_size_from_second_lod_found > max_gml_read_size_from_second_lod_found) &&
+                (found_max_lod < 3 || /* LOD3→4を探すとき*/ total_read_size_from_third_lod_found > max_gml_read_size_from_third_lod_found)
+                ) {
             break;
         }
     } while (!ifs.eof());

--- a/test/test_lod_searcher.cpp
+++ b/test/test_lod_searcher.cpp
@@ -52,7 +52,7 @@ namespace plateau::dataset {
     /// するとGMLファイル名とLODが出力されるので、変更前後でそのdiffをとって出力が同じであることを検証できます。
 //    TEST_F(LodSearcherTest, DisplayLodsRecursive) { // NOLINT
 //        // 下のパスを、ご自分のPCでテストしたいフォルダのパスに変更してください。
-//        const auto src_dir = fs::u8path(u8"F:\\Desktop\\plateauData\\15100_niigata-shi_2022_citygml_1_op\\udx");
+//        const auto src_dir = fs::u8path(u8"F:\\Desktop\\13100_tokyo23-ku_2022_citygml_1_2_op\\udx");
 //
 //        std::cout << "==== LOD Search Result ====" << std::endl;
 //        for(const auto& entry : fs::recursive_directory_iterator(src_dir)  ) {


### PR DESCRIPTION
範囲選択画面のローカルインポートで竹芝LOD4の建物が出てこない問題を修正