### PR TITLE
メッシュコードで非数値が渡された場合のハンドリング

### DIFF
--- a/src/dataset/mesh_code.cpp
+++ b/src/dataset/mesh_code.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include <plateau/dataset/mesh_code.h>
+#include <algorithm>
 
 namespace plateau::dataset {
     namespace {
@@ -97,6 +98,13 @@ namespace plateau::dataset {
     }
 
     MeshCode::MeshCode(const std::string& code) {
+        // メッシュコードの文字列が数字のみからなることをチェックします。
+        if (!std::all_of(code.cbegin(), code.cend(), isdigit)) {
+            is_valid_ = false;
+            return;
+        }
+
+        // メッシュコードのレベル（詳細度）をチェックします。
         is_valid_ = true;
         level_ = parseLevel(code);
         if (level_ < 0) {


### PR DESCRIPTION


## 動作確認
サーバーで竹芝サンプルを対象するとき、Releaseビルドでのみ範囲選択画面が開かないのを修正
