### PR TITLE
高さ合わせ機能のブラッシュアップ

### DIFF
--- a/include/plateau/height_map_alighner/height_map_aligner.h
+++ b/include/plateau/height_map_alighner/height_map_aligner.h
@@ -2,6 +2,7 @@
 #include <libplateau_api.h>
 #include "plateau/polygon_mesh/model.h"
 #include "plateau/height_map_generator/heightmap_types.h"
+#include <plateau/geometry/geo_reference.h>
 
 namespace plateau::heightMapAligner {
 
@@ -9,11 +10,23 @@ namespace plateau::heightMapAligner {
     class LIBPLATEAU_EXPORT HeightMapFrame {
     public:
         HeightMapFrame(plateau::heightMapGenerator::HeightMapT heightmap, int map_width, int map_height, float min_x_arg, float max_x_arg,
-                       float min_y_arg, float max_y_arg, float min_height_arg, float max_height_arg) :
+                       float min_y_arg, float max_y_arg, float min_height_arg, float max_height_arg, geometry::CoordinateSystem axis) :
                 heightmap(std::move(heightmap)), map_width(map_width), map_height(map_height),
                 min_x(min_x_arg), max_x(max_x_arg), max_y(max_y_arg), min_y(min_y_arg),
                 min_height(min_height_arg), max_height(max_height_arg)
         {
+            // 座標軸変換
+            const TVec3d min_v_row = TVec3d(min_x, min_y, min_height);
+            const TVec3d max_v_row = TVec3d(max_x, max_y, max_height);
+            const TVec3d min_v = geometry::GeoReference::convertAxisToENU(axis, min_v_row);
+            const TVec3d max_v = geometry::GeoReference::convertAxisToENU(axis, max_v_row);
+            min_x = (float)min_v.x;
+            min_y = (float)min_v.y;
+            min_height = (float)min_v.z;
+            max_x = (float)max_v.x;
+            max_y = (float)max_v.y;
+            max_height = (float)max_v.z;
+
             if(min_x > max_x) std::swap(min_x, max_x);
             if(min_y > max_y) std::swap(min_y, max_y);
             if(min_height > max_height) std::swap(min_height, max_height);
@@ -45,7 +58,7 @@ namespace plateau::heightMapAligner {
     public:
 
         /// コンストラクタで高さのオフセットを指定します。
-        explicit HeightMapAligner(double height_offset) : height_offset(height_offset) {}
+        HeightMapAligner(double height_offset, geometry::CoordinateSystem axis) : height_offset(height_offset), axis(axis){}
 
         void addHeightmapFrame(const HeightMapFrame& heightmap_frame);
 
@@ -66,5 +79,6 @@ namespace plateau::heightMapAligner {
     private:
         std::vector<HeightMapFrame> height_map_frames;
         const double height_offset;
+        geometry::CoordinateSystem axis;
     };
 }

--- a/include/plateau/height_map_alighner/height_map_aligner.h
+++ b/include/plateau/height_map_alighner/height_map_aligner.h
@@ -10,10 +10,10 @@ namespace plateau::heightMapAligner {
     class LIBPLATEAU_EXPORT HeightMapFrame {
     public:
         HeightMapFrame(plateau::heightMapGenerator::HeightMapT heightmap, int map_width, int map_height, float min_x_arg, float max_x_arg,
-                       float min_y_arg, float max_y_arg, float min_height_arg, float max_height_arg, geometry::CoordinateSystem axis) :
+                       float min_y_arg, float max_y_arg, float min_z_arg, float max_z_arg, geometry::CoordinateSystem axis) :
                 heightmap(std::move(heightmap)), map_width(map_width), map_height(map_height),
                 min_x(min_x_arg), max_x(max_x_arg), max_y(max_y_arg), min_y(min_y_arg),
-                min_height(min_height_arg), max_height(max_height_arg)
+                min_height(min_z_arg), max_height(max_z_arg)
         {
             // 座標軸変換
             const TVec3d min_v_row = TVec3d(min_x, min_y, min_height);

--- a/include/plateau/height_map_generator/heightmap_generator.h
+++ b/include/plateau/height_map_generator/heightmap_generator.h
@@ -15,10 +15,17 @@ namespace plateau::heightMapGenerator {
     class LIBPLATEAU_EXPORT HeightmapGenerator  {
     public:
         /// メイン関数です
-        HeightMapT generateFromMesh(const plateau::polygonMesh::Mesh& InMesh, size_t TextureWidth, size_t TextureHeight, const TVec2d& margin, geometry::CoordinateSystem coordinate, bool fillEdges, TVec3d& outMin, TVec3d& outMax, TVec2f& outUVMin, TVec2f& outUVMax);
+        HeightMapT generateFromMesh(
+                const plateau::polygonMesh::Mesh& InMesh, size_t TextureWidth, size_t TextureHeight,
+                const TVec2d& margin, geometry::CoordinateSystem coordinate,
+                bool fillEdges, bool applyConvolutionFilterForHeightMap,
+                TVec3d& outMin, TVec3d& outMax, TVec2f& outUVMin, TVec2f& outUVMax);
 
         /// extentなどがすでに決まっていることを前提にハイトマップ生成します。
-        HeightMapWithAlpha generateFromMeshAndTriangles(const plateau::polygonMesh::Mesh& in_mesh, size_t texture_width, size_t texture_height, bool fillEdges, TriangleList& triangles, const HeightMapT& initial_height_map);
+        HeightMapWithAlpha generateFromMeshAndTriangles(
+                const plateau::polygonMesh::Mesh& in_mesh, size_t texture_width, size_t texture_height,
+                bool fillEdges, bool applyConvolutionFilterForHeightMap,
+                const TriangleList& triangles, const HeightMapT& initial_height_map);
 
         static void savePngFile(const std::string& file_path, size_t width, size_t height, HeightMapElemT* data);
         static void saveRawFile(const std::string& file_path, size_t width, size_t height, HeightMapElemT* data);

--- a/include/plateau/polygon_mesh/mesh.h
+++ b/include/plateau/polygon_mesh/mesh.h
@@ -6,6 +6,7 @@
 #include "citygml/cityobject.h"
 #include "plateau/polygon_mesh/city_object_list.h"
 #include "plateau/polygon_mesh/quaternion.h"
+#include "plateau/geometry/geo_coordinate.h"
 #include <libplateau_api.h>
 #include <optional>
 
@@ -105,6 +106,9 @@ namespace plateau::polygonMesh {
         /// 同じSubMeshが複数回登場する場合、例えばSubMeshの配列が A→B→A→B のようになっている場合に、
         /// SubMeshを結合して A→B とすることで描画負荷を減らします。
         void combineSameSubMeshes();
+
+        void convertAxisToENUFrom(geometry::CoordinateSystem from_axis);
+        void convertAxisFromENUTo(geometry::CoordinateSystem to_axis);
 
     private:
         friend class MeshFactory;

--- a/src/c_wrapper/height_map_aligner_c.cpp
+++ b/src/c_wrapper/height_map_aligner_c.cpp
@@ -1,19 +1,22 @@
 #include "libplateau_c.h"
 #include <plateau/height_map_alighner/height_map_aligner.h>
+#include <plateau/geometry/geo_coordinate.h>
 #include <cstring>
 using namespace plateau::heightMapAligner;
 using namespace plateau::heightMapGenerator;
 using namespace plateau::polygonMesh;
+using namespace plateau::geometry;
 using namespace libplateau;
 
 extern "C" {
 
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API height_map_aligner_create(
             HeightMapAligner** aligner,
-            double height_offset
+            double height_offset,
+            CoordinateSystem axis
     ) {
         API_TRY{
-            *aligner = new HeightMapAligner(height_offset);
+            *aligner = new HeightMapAligner(height_offset, axis);
             return APIResult::Success;
         }
         API_CATCH;
@@ -34,15 +37,16 @@ extern "C" {
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API height_map_aligner_add_heightmap_frame(
             HeightMapAligner* const aligner,
             const HeightMapElemT* heightmap,
-            int heightmap_size, // size = width * height
-            int heightmap_width,
-            int heightmap_height,
-            float min_x,
-            float max_x,
-            float min_y,
-            float max_y,
-            float min_height,
-            float max_height
+            const int heightmap_size, // size = width * height
+            const int heightmap_width,
+            const int heightmap_height,
+            const float min_x,
+            const float max_x,
+            const float min_y,
+            const float max_y,
+            const float min_height,
+            const float max_height,
+            const CoordinateSystem axis
     ) {
         API_TRY{
             if(heightmap_size != heightmap_width * heightmap_height) {
@@ -51,7 +55,7 @@ extern "C" {
 
             auto map = HeightMapFrame(HeightMapT(heightmap, heightmap + heightmap_size), heightmap_width,
                                       heightmap_height, min_x, max_x, max_y, min_y, min_height,
-                                      max_height);
+                                      max_height, axis);
             aligner->addHeightmapFrame(map);
             return APIResult::Success;
         }

--- a/src/c_wrapper/heightmap_generator_c.cpp
+++ b/src/c_wrapper/heightmap_generator_c.cpp
@@ -13,11 +13,12 @@ extern "C" {
     // 注意 : out_heightmap_dataはコピー終了後にrelease_heightmap_dataを呼んで削除する必要あり
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API heightmap_generator_generate_from_mesh(
             Mesh* const src_mesh,
-            size_t TextureWidth,
-            size_t TextureHeight,
-            TVec3d margin,
-            CoordinateSystem coordinate,
-            bool fillEdges,
+            const size_t TextureWidth,
+            const size_t TextureHeight,
+            const TVec3d margin,
+            const CoordinateSystem coordinate,
+            const bool fillEdges,
+            const bool applyConvolutionFilterForHeightMap,
             TVec3d* outMin,
             TVec3d* outMax,
             TVec2f* outUVMin,
@@ -27,7 +28,10 @@ extern "C" {
     ) {
         API_TRY{
             HeightmapGenerator generator;
-            const auto& vec = generator.generateFromMesh(*src_mesh, TextureWidth, TextureHeight, TVec2d(margin.x, margin.y) , coordinate, fillEdges, *outMin, *outMax, *outUVMin, *outUVMax);
+            const auto& vec = generator.generateFromMesh(
+                    *src_mesh, TextureWidth, TextureHeight, TVec2d(margin.x, margin.y) , coordinate,
+                    fillEdges, applyConvolutionFilterForHeightMap,
+                    *outMin, *outMax, *outUVMin, *outUVMax);
             HeightMapElemT* heightmap_data = new HeightMapElemT [vec.size()];
             memcpy(heightmap_data, vec.data(), sizeof(HeightMapElemT) * vec.size());
             *out_heightmap_data = heightmap_data;
@@ -39,7 +43,7 @@ extern "C" {
     }
 
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API heightmap_save_png_file(
-            const char* filename, size_t width, size_t height, HeightMapElemT* data
+            const char* filename, const size_t width, const size_t height, HeightMapElemT* data
     ) {
         API_TRY{
             HeightmapGenerator::savePngFile(std::string(filename), width, height, data);
@@ -64,7 +68,7 @@ extern "C" {
     }
 
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API heightmap_save_raw_file(
-        const char* filename, size_t width, size_t height, HeightMapElemT* data
+        const char* filename, const size_t width, const size_t height, HeightMapElemT* data
     ) {
         API_TRY{
             HeightmapGenerator::saveRawFile(std::string(filename), width, height, data);
@@ -75,7 +79,7 @@ extern "C" {
 
     // 注意 : out_heightmap_dataはコピー終了後にrelease_heightmap_dataを呼んで削除する必要あり
     LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API heightmap_read_raw_file(
-    const char* filename, size_t width, size_t height, const HeightMapElemT** out_heightmap_data, size_t* dataSize
+    const char* filename, const size_t width, const size_t height, const HeightMapElemT** out_heightmap_data, size_t* dataSize
     ) {
         API_TRY{
             const auto & vec = HeightmapGenerator::readRawFile(std::string(filename), width, height);

--- a/src/height_map_aligner/height_map_aligner.cpp
+++ b/src/height_map_aligner/height_map_aligner.cpp
@@ -90,7 +90,7 @@ namespace plateau::heightMapAligner {
 
             mesh_triangles.Extent = land_extent;
             auto mesh_map = HeightmapGenerator().generateFromMeshAndTriangles(
-                    *mesh, land_map.map_width, land_map.map_height, false,
+                    *mesh, land_map.map_width, land_map.map_height, false, true,
                     mesh_triangles, land_map.heightmap
             );
 

--- a/src/height_map_aligner/height_map_aligner.cpp
+++ b/src/height_map_aligner/height_map_aligner.cpp
@@ -33,8 +33,8 @@ namespace plateau::heightMapAligner {
                 else dist_x = 0;
 
                 // y
-                if(v.z < m.min_y) dist_y = m.min_y - v.z;
-                else if(v.z > m.max_y) dist_y = v.z - m.max_y;
+                if(v.y < m.min_y) dist_y = m.min_y - v.y;
+                else if(v.y > m.max_y) dist_y = v.y - m.max_y;
                 else dist_y = 0;
 
                 // 距離
@@ -48,8 +48,9 @@ namespace plateau::heightMapAligner {
             return map;
         }
 
-        void alignMesh(Mesh* mesh, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length) {
-
+        void alignMesh(Mesh* mesh, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length, const CoordinateSystem axis) {
+            // 座標系はENUで処理
+            mesh->convertAxisToENUFrom(axis);
 
             // OpenMeshのSubdivision機能を使いたいので、OpenMeshのメッシュを作成します。
             // OpenMeshについてはこちらを参照してください: https://www.graphics.rwth-aachen.de/media/openmesh_static/Documentations/OpenMesh-6.1-Documentation/a00046.html
@@ -71,22 +72,30 @@ namespace plateau::heightMapAligner {
 
             // 高さをハイトマップに合わせます
             for(auto& vertex : vertices) {
-                vertex.y = map.posToHeight(TVec2d(vertex.x, vertex.z), height_offset);
+                vertex.z = map.posToHeight(TVec2d(vertex.x, vertex.y), height_offset);
             }
+
+            // 座標系を元に戻す
+            mesh->convertAxisFromENUTo(axis);
         }
 
-        void alignMeshInvert(Mesh* mesh, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance) {
+        void alignMeshInvert(Mesh* mesh, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance, const CoordinateSystem axis) {
+
+
+            // 頂点をコピーしてENUに変換します。
+            auto vertices = std::vector<TVec3<double>>(mesh->getVertices());
+            for(auto& vertex : vertices) {
+                vertex = geometry::GeoReference::convertAxisToENU(axis, vertex);
+            }
 
             // 与えられたメッシュだけのハイトマップを作ります。
             // この際、範囲などの条件を地形ハイトマップと同じに設定することで、後で比較できるようにします。
-            auto& vertices = mesh->getVertices();
             if(vertices.empty()) return;
             auto& land_map = chooseNearestMap(maps, vertices.at(0));
-            constexpr CoordinateSystem coordinate = CoordinateSystem::EUN;
-            auto mesh_triangles = TriangleList::generateFromMesh(mesh->getIndices(), vertices, coordinate);
+            auto mesh_triangles = TriangleList::generateFromMesh(mesh->getIndices(), vertices, CoordinateSystem::ENU);
             auto land_extent = HeightMapExtent();
-            land_extent.Min = TVec3d(land_map.min_x, land_map.min_y, land_map.min_height); // EUN to ENU
-            land_extent.Max = TVec3d(land_map.max_x, land_map.max_y, land_map.max_height); // EUN to ENU
+            land_extent.Min = TVec3d(land_map.min_x, land_map.min_y, land_map.min_height);
+            land_extent.Max = TVec3d(land_map.max_x, land_map.max_y, land_map.max_height);
 
             mesh_triangles.Extent = land_extent;
             auto mesh_map = HeightmapGenerator().generateFromMeshAndTriangles(
@@ -115,31 +124,31 @@ namespace plateau::heightMapAligner {
             }
         }
 
-        void alignNode(Node& node, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length) {
+        void alignNode(Node& node, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length, const CoordinateSystem axis) {
             auto mesh = node.getMesh();
             if(mesh == nullptr) return;
-            alignMesh(mesh, maps, height_offset, max_edge_length);
+            alignMesh(mesh, maps, height_offset, max_edge_length, axis);
         }
 
-        void alignNodeInvert(Node& node, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance) {
+        void alignNodeInvert(Node& node, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance, const CoordinateSystem axis) {
             auto mesh = node.getMesh();
             if(mesh == nullptr) return;
-            alignMeshInvert(mesh, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance);
+            alignMeshInvert(mesh, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance, axis);
         }
 
-        void alignRecursive(Node& node, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length) {
-            alignNode(node, maps, height_offset, max_edge_length);
+        void alignRecursive(Node& node, std::vector<HeightMapFrame>& maps, const double height_offset, const float max_edge_length, const CoordinateSystem axis) {
+            alignNode(node, maps, height_offset, max_edge_length, axis);
             for(int i=0; i<node.getChildCount(); i++) {
                 auto& child = node.getChildAt(i);
-                alignRecursive(child, maps, height_offset, max_edge_length);
+                alignRecursive(child, maps, height_offset, max_edge_length, axis);
             }
         }
 
-        void alignRecursiveInvert(Node& node, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance) {
-            alignNodeInvert(node, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance);
+        void alignRecursiveInvert(Node& node, std::vector<HeightMapFrame>& maps, const int alpha_expand_width_cartesian, const int alpha_averaging_width_cartesian, const double height_offset, const float skip_threshold_of_map_land_distance, const CoordinateSystem axis) {
+            alignNodeInvert(node, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance, axis);
             for(int i=0; i<node.getChildCount(); i++) {
                 auto& child = node.getChildAt(i);
-                alignRecursiveInvert(child, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance);
+                alignRecursiveInvert(child, maps, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset, skip_threshold_of_map_land_distance, axis);
             }
         }
 
@@ -157,7 +166,7 @@ namespace plateau::heightMapAligner {
         if(height_map_frames.empty()) throw std::runtime_error("HeightMapAligner::align: No height map frame added.");
         for(int i=0; i<model.getRootNodeCount(); i++){
             auto& node = model.getRootNodeAt(i);
-            alignRecursive(node, height_map_frames, height_offset, max_edge_length);
+            alignRecursive(node, height_map_frames, height_offset, max_edge_length, axis);
         }
     }
 
@@ -165,7 +174,7 @@ namespace plateau::heightMapAligner {
         if(height_map_frames.empty()) throw std::runtime_error("HeightMapAligner::alignInvert: No height map frame added.");
         for(int i=0; i<model.getRootNodeCount(); i++){
             auto& node = model.getRootNodeAt(i);
-            alignRecursiveInvert(node, height_map_frames, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset_inv, skip_threshold_of_map_land_distance);
+            alignRecursiveInvert(node, height_map_frames, alpha_expand_width_cartesian, alpha_averaging_width_cartesian, height_offset_inv, skip_threshold_of_map_land_distance, axis);
         }
     }
 

--- a/src/height_map_aligner/open_mesh_converter.cpp
+++ b/src/height_map_aligner/open_mesh_converter.cpp
@@ -80,7 +80,7 @@ namespace plateau::heightMapAligner {
         p_vertices.reserve(next_vert_count);
         for(MeshType::VertexIter v_itr = om_mesh.vertices_begin(); v_itr != om_mesh.vertices_end(); ++v_itr) {
             MeshType::Point point = om_mesh.point(*v_itr);
-            p_vertices.push_back(TVec3d(point[0], point[1], point[2]));
+            p_vertices.emplace_back(point[0], point[1], point[2]);
         }
 
         // indices
@@ -106,7 +106,7 @@ namespace plateau::heightMapAligner {
             auto prop_game_mat = om_mesh.property(game_material_id_prop, *f_itr);
             // ゲームマテリアルIDが変わったとき、または最後のときにSubMeshを追加します。
             if((/*prop_game_mat.has_value() && */game_mat_id != prop_game_mat) || (f_itr+1) == om_mesh.faces_end()) {
-                submeshes.emplace_back(submesh_start, face_id * 3 - 1, "", nullptr, game_mat_id.has_value() ? game_mat_id.value() : -1);
+                submeshes.emplace_back(submesh_start, face_id * 3 + 2, "", nullptr, game_mat_id.has_value() ? game_mat_id.value() : -1);
                 game_mat_id = prop_game_mat;
                 submesh_start = face_id * 3;
             }

--- a/src/polygon_mesh/mesh.cpp
+++ b/src/polygon_mesh/mesh.cpp
@@ -3,6 +3,7 @@
 
 #include "citygml/texture.h"
 #include "citygml/cityobject.h"
+#include "plateau/geometry/geo_reference.h"
 
 namespace plateau::polygonMesh {
     using namespace citygml;
@@ -274,5 +275,17 @@ namespace plateau::polygonMesh {
 
     void Mesh::setCityObjectList(const CityObjectList& city_obj_list) {
         city_object_list_ = city_obj_list;
+    }
+
+    void Mesh::convertAxisToENUFrom(geometry::CoordinateSystem from_axis) {
+        for(auto& vertex : vertices_) {
+            vertex = geometry::GeoReference::convertAxisToENU(from_axis, vertex);
+        }
+    }
+
+    void Mesh::convertAxisFromENUTo(geometry::CoordinateSystem to_axis) {
+        for(auto& vertex : vertices_) {
+            vertex = geometry::GeoReference::convertAxisFromENUTo(to_axis, vertex);
+        }
     }
 }

--- a/test/test_height_map_aligner.cpp
+++ b/test/test_height_map_aligner.cpp
@@ -9,9 +9,9 @@ class HeightMapAlignerTest : public ::testing::Test {
 };
 
 TEST_F(HeightMapAlignerTest, on_zero_heightmap) {
-    auto aligner = HeightMapAligner(0);
+    auto aligner = HeightMapAligner(0, plateau::geometry::CoordinateSystem::ENU);
     auto model = plateau::polygonMesh::Model();
-    auto frame = HeightMapFrame(std::vector<uint16_t>(), 0, 0, 0, 0, 0, 0, 0, 0);
+    auto frame = HeightMapFrame(std::vector<uint16_t>(), 0, 0, 0, 0, 0, 0, 0, 0, plateau::geometry::CoordinateSystem::ENU);
     aligner.addHeightmapFrame(frame);
     aligner.align(model, 4);
 }

--- a/test/test_height_map_aligner.cpp
+++ b/test/test_height_map_aligner.cpp
@@ -1,17 +1,93 @@
 #include "gtest/gtest.h"
 #include "citygml/citygml.h"
 #include "plateau/height_map_alighner/height_map_aligner.h"
+#include <plateau/height_map_generator/heightmap_types.h>
+#include <memory>
+#include <cmath>
 
 using namespace plateau::heightMapAligner;
+using namespace plateau::heightMapGenerator;
+using namespace plateau::polygonMesh;
+using namespace plateau::geometry;
 
 class HeightMapAlignerTest : public ::testing::Test {
 
 };
 
-TEST_F(HeightMapAlignerTest, on_zero_heightmap) {
+TEST_F(HeightMapAlignerTest, AlignOnZeroHeightMap) { // NOLINT
     auto aligner = HeightMapAligner(0, plateau::geometry::CoordinateSystem::ENU);
     auto model = plateau::polygonMesh::Model();
     auto frame = HeightMapFrame(std::vector<uint16_t>(), 0, 0, 0, 0, 0, 0, 0, 0, plateau::geometry::CoordinateSystem::ENU);
     aligner.addHeightmapFrame(frame);
     aligner.align(model, 4);
+}
+
+TEST_F(HeightMapAlignerTest, Align) { // NOLINT
+    // ポリゴンが1つだけのモデルを作成します
+    auto model = Model();
+    auto node = Node("test_node");
+    auto src_vertices = std::vector<TVec3d>{{0,0,-1}, {0,1, -1}, {1,1,-1}};
+    auto src_indices = std::vector<unsigned>{0, 1, 2};
+    auto src_uv1 = UV{{0, 0}, {0,0}, {0,0}};
+    auto src_uv4 = UV{{0,0}, {0,0}, {0,0}};
+    auto src_sub_meshes = std::vector<SubMesh>{SubMesh(0, 2, "", nullptr, 1)};
+    auto src_mesh = std::make_unique<Mesh>(
+            std::vector<TVec3d>(src_vertices),
+            std::vector<unsigned>(src_indices),
+            std::vector<TVec2f>(src_uv1),
+            std::vector<TVec2f>(src_uv4),
+            std::vector<SubMesh>(src_sub_meshes),
+            CityObjectList());
+    node.setMesh(std::move(src_mesh));
+    model.addNode(std::move(node));
+
+    // alignを実行します
+    auto height_map = HeightMapT{0};
+    auto height_map_frame = HeightMapFrame(height_map, 1, 1, 0, 1, 0, 1, 1, 2, CoordinateSystem::ENU);
+    auto aligner = HeightMapAligner(0.5, CoordinateSystem::ENU);
+    aligner.addHeightmapFrame(height_map_frame);
+    aligner.align(model, 999);
+
+    // 実行結果をチェックします
+    auto dst_mesh = model.getRootNodeAt(0).getMesh();
+
+    // 頂点チェック
+    auto dst_vertices = dst_mesh->getVertices();
+    ASSERT_EQ(src_vertices.size(), dst_vertices.size()) << "alignしても頂点数は同じ";
+    auto expect_vertices = std::vector<TVec3d>{{0,0,1.5}, {0,1,1.5}, {1,1,1.5}};
+    for(int i=0; i<src_vertices.size(); i++) {
+        const auto dist = (dst_vertices.at(i) - expect_vertices.at(i)).length();
+        ASSERT_TRUE(dist < 0.0001) << "alignによる頂点の高さの変化";
+    }
+
+    // indicesチェック
+    auto dst_indices = dst_mesh->getIndices();
+    ASSERT_EQ(src_indices.size(), dst_indices.size()) << "alignしても三角形数は同じ";
+    for(int i=0; i<src_indices.size(); i++) {
+        ASSERT_EQ(dst_indices.at(i), src_indices.at(i)) << "alignしても三角形の番号は変わらない";
+    }
+
+    // UV1チェック
+    auto dst_uv1 = dst_mesh->getUV1();
+    ASSERT_EQ(src_uv1.size(), dst_uv1.size()) << "alignしてもUV1の数は同じ";
+    for(int i=0; i<src_uv1.size(); i++) {
+        ASSERT_EQ(dst_uv1.at(i), src_uv1.at(i)) << "alignしてもUV1の値は変わらない";
+    }
+
+    // UV4チェック
+    auto dst_uv4 = dst_mesh->getUV4();
+    ASSERT_EQ(src_uv4.size(), dst_uv4.size()) << "alignしてもUV4の数は同じ";
+    for(int i=0; i<src_uv4.size(); i++) {
+        ASSERT_EQ(dst_uv4.at(i), src_uv4.at(i)) << "alignしてもUV4の値は変わらない";
+    }
+
+    // SubMeshチェック
+    auto dst_sub_meshes = dst_mesh->getSubMeshes();
+    ASSERT_EQ(src_sub_meshes.size(), dst_sub_meshes.size()) << "alignしてもSubMeshの数は同じ";
+    for(int i=0; i < src_sub_meshes.size(); i++) {
+        ASSERT_EQ(dst_sub_meshes.at(i).getStartIndex(), src_sub_meshes.at(i).getStartIndex()) << "alignしてもSubMeshのStartIndexは変わらない";
+        ASSERT_EQ(dst_sub_meshes.at(i).getEndIndex(), src_sub_meshes.at(i).getEndIndex()) << "alignしてもSubMeshのEndIndexは変わらない";
+        ASSERT_EQ(dst_sub_meshes.at(i).getGameMaterialID(), src_sub_meshes.at(i).getGameMaterialID()) << "alignしてもSubMeshのgameMaterialIDは変わらない";
+    }
+
 }

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/TestHeightMapAlign/TestHeightMapAligner.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/TestHeightMapAlign/TestHeightMapAligner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PLATEAU.Geometries;
 using PLATEAU.HeightMapAlign;
 using PLATEAU.PolygonMesh;
 
@@ -13,9 +14,9 @@ public class TestHeightMapAligner
     {
         using var model = Model.Create();
         var emptyMap = Array.Empty<UInt16>();
-        using var aligner = HeightMapAligner.Create(0);
+        using var aligner = HeightMapAligner.Create(0, CoordinateSystem.EUN);
         Assert.AreEqual(0, aligner.HeightMapCount);
-        aligner.AddHeightmapFrame(emptyMap, 0, 0, 0, 0,0 , 0, 0, 0);
+        aligner.AddHeightmapFrame(emptyMap, 0, 0, 0, 0,0 , 0, 0, 0, CoordinateSystem.EUN);
         Assert.AreEqual(1, aligner.HeightMapCount);
         aligner.AlignInvert(model);
         aligner.Align(model);

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Texture/HeightmapGeneratorTest.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/Texture/HeightmapGeneratorTest.cs
@@ -36,7 +36,7 @@ namespace PLATEAU.Test.Texture
             PlateauVector2d margin = new PlateauVector2d(0, 0);
 
             HeightmapGenerator gen = new HeightmapGenerator();
-            gen.GenerateFromMesh(mesh, textureWidth, textureHeight, margin, true, out var min, out var max, out var minUV, out var maxUV, out var outData);
+            gen.GenerateFromMesh(mesh, textureWidth, textureHeight, margin, true, true, out var min, out var max, out var minUV, out var maxUV, out var outData);
             Assert.AreEqual(textureWidth * textureHeight, outData.Length);
         }
 

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.sln.DotSettings
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.sln.DotSettings
@@ -18,6 +18,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RUF/@EntryIndexedValue">RUF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SRS/@EntryIndexedValue">SRS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=URL/@EntryIndexedValue">URL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UV/@EntryIndexedValue">UV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=WNU/@EntryIndexedValue">WNU</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=WUN/@EntryIndexedValue">WUN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="COT_" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="GT_" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="COT_TIN" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="WM_" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/HeightMapAlign/HeightMapAligner.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/HeightMapAlign/HeightMapAligner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using PLATEAU.Geometries;
 using PLATEAU.Interop;
 using PLATEAU.Native;
 using PLATEAU.PolygonMesh;
@@ -14,9 +15,9 @@ namespace PLATEAU.HeightMapAlign
         private const float AlignInvertHeightOffset = -0.15f; // 逆高さ合わせで、土地を対象と比べてどの高さに合わせるか（直交座標系）
         private const float SkipThresholdOfMapLandDistance = 0.5f; // 逆高さ合わせで、土地との距離がこの値以上の箇所は高さ合わせしない（直交座標系）
         
-        public static HeightMapAligner Create(double heightOffset)
+        public static HeightMapAligner Create(double heightOffset, CoordinateSystem axis)
         {
-            var result = NativeMethods.height_map_aligner_create(out var createdPtr, heightOffset);
+            var result = NativeMethods.height_map_aligner_create(out var createdPtr, heightOffset, axis);
             DLLUtil.CheckDllError(result);
             return new HeightMapAligner(createdPtr);
         }
@@ -25,13 +26,13 @@ namespace PLATEAU.HeightMapAlign
         {
         }
 
-        public void AddHeightmapFrame(UInt16[] heightMapData, int heightMapWidth, int heightMapHeight, float minX, float maxX, float minY, float maxY, float minHeight, float maxHeight)
+        public void AddHeightmapFrame(UInt16[] heightMapData, int heightMapWidth, int heightMapHeight, float minX, float maxX, float minY, float maxY, float minZ, float maxZ, CoordinateSystem axis)
         {
             if (heightMapData.Length != heightMapWidth * heightMapHeight)
             {
                 throw new ArgumentException($"{nameof(heightMapData)}のサイズとWidth,Heightの積が一致しません。");
             }
-            var apiResult = NativeMethods.height_map_aligner_add_heightmap_frame(Handle, heightMapData, heightMapData.Length, heightMapWidth, heightMapHeight, minX, maxX, minY, maxY, minHeight, maxHeight);
+            var apiResult = NativeMethods.height_map_aligner_add_heightmap_frame(Handle, heightMapData, heightMapData.Length, heightMapWidth, heightMapHeight, minX, maxX, minY, maxY, minZ, maxZ, axis);
             DLLUtil.CheckDllError(apiResult);
         }
         
@@ -87,7 +88,8 @@ namespace PLATEAU.HeightMapAlign
             [DllImport(DLLUtil.DllName)]
             internal static extern APIResult height_map_aligner_create(
                 out IntPtr createdPtr,
-                [In] double heightOffset
+                [In] double heightOffset,
+                [In] CoordinateSystem axis
             );
             
             [DllImport(DLLUtil.DllName)]
@@ -106,8 +108,9 @@ namespace PLATEAU.HeightMapAlign
                 [In] float maxX,
                 [In] float minY,
                 [In] float maxY,
-                [In] float minHeight,
-                [In] float maxHeight
+                [In] float minZ,
+                [In] float maxZ,
+                [In] CoordinateSystem axis
             );
             
                 [DllImport(DLLUtil.DllName)]

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/HeightMapAlign/HeightMapAligner.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/HeightMapAlign/HeightMapAligner.cs
@@ -12,8 +12,8 @@ namespace PLATEAU.HeightMapAlign
         private const float MaxEdgeLength = 4; // 高さ合わせのためメッシュを細分化するときの、最大の辺の長さ。だいたい4mくらいが良さそう。
         private const int AlphaExpandWidthCartesian = 2; // 逆高さ合わせのアルファの平滑化処理において、不透明部分を広げる幅（直交座標系）
         private const int AlphaAverageWidthCartesian = 2; // 逆高さ合わせのアルファの平滑化処理において、周りの平均を取る幅（直交座標系）
-        private const float AlignInvertHeightOffset = -0.15f; // 逆高さ合わせで、土地を対象と比べてどの高さに合わせるか（直交座標系）
-        private const float SkipThresholdOfMapLandDistance = 0.5f; // 逆高さ合わせで、土地との距離がこの値以上の箇所は高さ合わせしない（直交座標系）
+        private const float AlignInvertHeightOffset = -0.2f; // 逆高さ合わせで、土地を対象と比べてどの高さに合わせるか（直交座標系）
+        private const float SkipThresholdOfMapLandDistance = 0.8f; // 逆高さ合わせで、土地との距離がこの値以上の箇所は高さ合わせしない（直交座標系）
         
         public static HeightMapAligner Create(double heightOffset, CoordinateSystem axis)
         {

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Texture/HeightmapGenerator.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Texture/HeightmapGenerator.cs
@@ -11,22 +11,25 @@ namespace PLATEAU.Texture
         private const int UInt16Max = 65535;
         
         public void GenerateFromMesh(PolygonMesh.Mesh inMesh, int textureWidth, int textureHeight, 
-            PlateauVector2d Margin, bool fillEdges, out PlateauVector3d Min, out PlateauVector3d Max, 
-            out PlateauVector2f MinUV, out PlateauVector2f MaxUV, out UInt16[] HeightData )
+            PlateauVector2d margin, bool fillEdges, bool applyConvolutionFilterForHeightMap,
+            out PlateauVector3d min, out PlateauVector3d max, 
+            out PlateauVector2f minUV, out PlateauVector2f maxUV, out UInt16[] heightData )
         {
             var apiResult =
-                NativeMethods.heightmap_generator_generate_from_mesh(inMesh.Handle, textureWidth, textureHeight, new PlateauVector3d(Margin.X, Margin.Y, 0), CoordinateSystem.EUN, fillEdges,
-                out Min, out Max , out MinUV, out MaxUV, out IntPtr HeightmapDataPtr, out int DataSize);
+                NativeMethods.heightmap_generator_generate_from_mesh(
+                    inMesh.Handle, textureWidth, textureHeight, new PlateauVector3d(margin.X, margin.Y, 0),
+                    CoordinateSystem.EUN, fillEdges, applyConvolutionFilterForHeightMap,
+                    out min, out max , out minUV, out maxUV, out IntPtr heightmapDataPtr, out int dataSize);
             DLLUtil.CheckDllError(apiResult);
 
-            byte[] outData = DLLUtil.PtrToBytes(HeightmapDataPtr, sizeof(UInt16) * DataSize);
-            NativeMethods.release_heightmap_data(HeightmapDataPtr);
+            byte[] outData = DLLUtil.PtrToBytes(heightmapDataPtr, sizeof(UInt16) * dataSize);
+            NativeMethods.release_heightmap_data(heightmapDataPtr);
 
-            HeightData = new UInt16[DataSize];
+            heightData = new UInt16[dataSize];
             int byteIndex = 0;
-            for (int i = 0; i < HeightData.Length; i++)
+            for (int i = 0; i < heightData.Length; i++)
             {
-                HeightData[i] = BitConverter.ToUInt16(outData, byteIndex);
+                heightData[i] = BitConverter.ToUInt16(outData, byteIndex);
                 byteIndex += 2;
             }
         }
@@ -169,6 +172,7 @@ namespace PLATEAU.Texture
                 [In] PlateauVector3d margin,
                 [In] CoordinateSystem coordinate,
                 [In] bool fillEdges,
+                [In] bool applyConvolutionFilterForHeightMap,
                 out PlateauVector3d min,
                 out PlateauVector3d max,
                 out PlateauVector2f minUV,


### PR DESCRIPTION
## 実装内容
高さ合わせについて：
- 高さ合わせと平滑化のパラメーターを調整可能にしました
- 他の座標系に対応しました
- align関数のユニットテストを追加し、SubMeshが正しくないバグを修正しました

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
unity sdkのadjust_height2ブランチで動作確認できます


