### PR TITLE
FBXエクスポートで、同名のテクスチャ付きのマテリアルがあるとマテリアルが崩れるバグを修正

### DIFF
--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -238,7 +238,14 @@ namespace plateau::meshWriter {
                     }
                 } else {
                     FbxString material_name = fs::u8path(texture_path).filename().replace_extension("").u8string().c_str();
-                    fbx_material = FbxSurfacePhong::Create(fbx_scene, material_name);
+
+                    // 経験上、同じマテリアルから複数のFBXマテリアルが生成されるとサブメッシュの順序が崩れる(Blender,Unityで確認)ので、前と同名のマテリアルが来たらマテリアルをCreateせずに設定します。。
+                    fbx_material = fbx_scene->GetMaterial(material_name); // 同じマテリアルがすでにあればそれを利用します。
+                    if(!fbx_material) {
+                        // 同じマテリアルがなければ生成します。
+                        fbx_material = FbxSurfacePhong::Create(fbx_scene, material_name);
+                    }
+
                     FbxProperty FbxColorProperty = fbx_material->FindProperty(FbxSurfaceMaterial::sDiffuse);
                     if (FbxColorProperty.IsValid()) {
                         //Create a fbx property

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -225,6 +225,7 @@ namespace plateau::meshWriter {
             const auto& sub_meshes = mesh.getSubMeshes();
             for (const auto& sub_mesh : sub_meshes) {
                 FbxSurfaceMaterial* fbx_material;
+                bool is_new_material = false;
                 const auto& texture_path = sub_mesh.getTexturePath();
                 if (texture_path.empty()) {
                     // ここでFBXのマテリアル名が同じになると、勝手に結合される可能性があります。
@@ -235,15 +236,15 @@ namespace plateau::meshWriter {
                         fbx_material = FbxSurfacePhong::Create(fbx_scene, default_material_name.Buffer());
                         ((FbxSurfacePhong*)fbx_material)->Diffuse.Set(FbxDouble3(0.72, 0.72, 0.72));
                         ((FbxSurfacePhong*)fbx_material)->DiffuseFactor.Set(1.);
+                        is_new_material = true;
                     }
                 } else {
                     FbxString material_name = fs::u8path(texture_path).filename().replace_extension("").u8string().c_str();
-
-                    // 経験上、同じマテリアルから複数のFBXマテリアルが生成されるとサブメッシュの順序が崩れる(Blender,Unityで確認)ので、前と同名のマテリアルが来たらマテリアルをCreateせずに設定します。。
                     fbx_material = fbx_scene->GetMaterial(material_name); // 同じマテリアルがすでにあればそれを利用します。
                     if(!fbx_material) {
                         // 同じマテリアルがなければ生成します。
                         fbx_material = FbxSurfacePhong::Create(fbx_scene, material_name);
+                        is_new_material = true;
                     }
 
                     FbxProperty FbxColorProperty = fbx_material->FindProperty(FbxSurfaceMaterial::sDiffuse);
@@ -258,7 +259,12 @@ namespace plateau::meshWriter {
                     }
                 }
 
-                const int material_index = fbx_node->AddMaterial(fbx_material);
+                int material_index;
+                if(is_new_material) {
+                    material_index = fbx_node->AddMaterial(fbx_material);
+                } else {
+                    material_index = fbx_node->GetMaterialIndex(fbx_material->GetName());
+                }
 
                 const unsigned triangle_count = (sub_mesh.getEndIndex() - sub_mesh.getStartIndex() + 1) / 3;
 


### PR DESCRIPTION
## 確認方法
Unity SDKでメッシュコード53394641をAssetsに保存したとき、一部マテリアルが剥がれるのが改善している

before:
![image](https://github.com/user-attachments/assets/8beacfca-f25a-4dfb-93e6-dd2ab9d3c366)

after:
![image](https://github.com/user-attachments/assets/76cee12e-996e-4ad5-9821-b20c071c1f81)
