### PR TITLE
同じSubMeshを結合する機能について、diffuseなど数値情報が設定されていると動作しない問題を修正

### DIFF
--- a/src/polygon_mesh/sub_mesh.cpp
+++ b/src/polygon_mesh/sub_mesh.cpp
@@ -84,24 +84,88 @@ namespace plateau::polygonMesh {
 
     }
 
+
+    namespace {
+        bool compareTVec3f(const TVec3f& l, const TVec3f& r) {
+            // lがrより小さいときにtrueを返します。
+            constexpr float epsilon = 0.0001f;
+            if(std::abs(l.x - l.y) > epsilon) return l.x < r.x;
+            if(std::abs(l.y - l.y) > epsilon) return l.y < r.y;
+            if(std::abs(l.z - l.z) > epsilon) return l.z < r.z;
+            return false; // areEqualTVec3f() がtrueを返すときにこの行が実行されるようにします。
+        }
+
+        bool areEqualTVec3f(const TVec3f& l, const TVec3f& r) {
+            // compareTVec3f() の最後の行のreturn falseが実行されるケースを記述します。
+            constexpr float epsilon = 0.0001f;
+            return std::abs(l.x - r.x) <= epsilon && std::abs(l.y - r.y) <= epsilon && std::abs(l.z - r.z) <= epsilon;
+        }
+    }
+
     bool SubMesh::isAppearanceEqual(const plateau::polygonMesh::SubMesh& other) const {
-        bool ret = texture_path_ == other.texture_path_ &&
-                material_.get() == other.material_.get() &&
-                game_material_id_ == other.game_material_id_;
-        return ret;
+
+        // 留意: ここを編集するときは、SubMeshCompareByAppearance::operator() も対応するように編集してください。
+        if(getGameMaterialID() != other.getGameMaterialID()) return false;
+        if(getTexturePath() != other.getTexturePath()) return false;
+        const auto mat_s = getMaterial();
+        const auto mat_o = other.getMaterial();
+        if(mat_s.get() == mat_o.get()) return true;
+        if(mat_s->getDiffuse() != mat_o->getDiffuse()) return false;
+        if(mat_s->getEmissive() != mat_o->getEmissive()) return false;
+        if(mat_s->getSpecular() != mat_o->getSpecular()) return false;
+        if(mat_s->getAmbientIntensity() != mat_o->getAmbientIntensity()) return false;
+        if(mat_s->getShininess() != mat_o->getShininess()) return false;
+        if(mat_s->getTransparency() != mat_o->getTransparency()) return false;
+        if(mat_s->isSmooth() != mat_o->isSmooth()) return false;
+        return true;
     }
 
     bool SubMeshCompareByAppearance::operator()(const plateau::polygonMesh::SubMesh& lhs,
                                                 const plateau::polygonMesh::SubMesh& rhs) const {
+
+        // 留意: ここを編集するときは、SubMesh::isAppearanceEqual も対応するように編集してください。
+        //      lhsがrhsよりも小さい場合にtrueを返します。
+
+        // gameMaterialの比較
         if(lhs.getGameMaterialID() != rhs.getGameMaterialID()) return lhs.getGameMaterialID() < rhs.getGameMaterialID();
-        auto& tex_path_l = lhs.getTexturePath();
-        auto& tex_path_r = rhs.getTexturePath();
+
+        // テクスチャパスの比較
+        const auto& tex_path_l = lhs.getTexturePath();
+        const auto& tex_path_r = rhs.getTexturePath();
         if(tex_path_l != tex_path_r) {
-            bool ret = tex_path_l < tex_path_r;
-            return ret;
+            return tex_path_l < tex_path_r;
         }
-        bool ret = lhs.getMaterial().get() < rhs.getMaterial().get();
-        return ret;
+
+        // 数値上のマテリアルの比較
+        constexpr float epsilon = 0.0001f;
+        const auto mat_l = lhs.getMaterial();
+        const auto mat_r = rhs.getMaterial();
+        if(!mat_l && !mat_r) return true;
+        if(mat_l && !mat_r) return false;
+        if(!mat_l && mat_r) return true;
+        const auto diffuse_l = mat_l->getDiffuse();
+        const auto diffuse_r = mat_r->getDiffuse();
+        if(!areEqualTVec3f(diffuse_l, diffuse_r)) return compareTVec3f(diffuse_l, diffuse_r);
+        const auto emissive_l = mat_l->getEmissive();
+        const auto emissive_r = mat_r->getEmissive();
+        if(!areEqualTVec3f(emissive_l, emissive_r)) return compareTVec3f(emissive_l, emissive_r);
+        const auto specular_l = mat_l->getSpecular();
+        const auto specular_r = mat_r->getSpecular();
+        if(!areEqualTVec3f(specular_l, specular_r)) return compareTVec3f(specular_l, specular_r);
+        const auto ambient_l = mat_l->getAmbientIntensity();
+        const auto ambient_r = mat_r->getAmbientIntensity();
+        if(std::abs(ambient_l - ambient_r) > epsilon) return ambient_l < ambient_r;
+        const auto shiness_l = mat_l->getShininess();
+        const auto shiness_r = mat_r->getShininess();
+        if(std::abs(shiness_l - shiness_r) > epsilon) return shiness_l < shiness_r;
+        const auto transparency_l = mat_l->getTransparency();
+        const auto transparency_r = mat_r->getTransparency();
+        if(std::abs(transparency_l - transparency_r) > epsilon) return transparency_l < transparency_r;
+        const auto smooth_l = mat_l->isSmooth();
+        const auto smooth_r = mat_r->isSmooth();
+        if(smooth_l != smooth_r) return smooth_l < smooth_r;
+
+        return false; // 等しい
     }
 
 


### PR DESCRIPTION


## 動作確認
文京区のメッシュコード53394641の建物を地域単位でインポートしたとき、  
同一マテリアルの結合がうまくいかなかったのがうまくいくようになった
