### PR TITLE
同一SubMesh結合機能がリリースビルドで動かないのを修正

### DIFF
--- a/src/polygon_mesh/sub_mesh.cpp
+++ b/src/polygon_mesh/sub_mesh.cpp
@@ -110,6 +110,8 @@ namespace plateau::polygonMesh {
         const auto mat_s = getMaterial();
         const auto mat_o = other.getMaterial();
         if(mat_s.get() == mat_o.get()) return true;
+        if(!mat_s && mat_o) return false;
+        if(mat_s && !mat_o) return false;
         if(mat_s->getDiffuse() != mat_o->getDiffuse()) return false;
         if(mat_s->getEmissive() != mat_o->getEmissive()) return false;
         if(mat_s->getSpecular() != mat_o->getSpecular()) return false;


### PR DESCRIPTION


## 動作確認
Unityで文京区のメッシュコード53394641の建物を地域単位でインポートできる


