### PR TITLE
主要地物内同一マテリアルへの変換で、CityObjectListの情報が欠ける問題を修正

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -14,8 +14,10 @@
     <mapping directory="$PROJECT_DIR$/3rdparty/openssl-cmake" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/xerces-c" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/3rdparty/zlib" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/out/build/x64-Release-Unreal-Mac/RapidJSON-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/out/build/x64-Release-Unreal-Mac/RapidJSON-src/thirdparty/gtest" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Debug-Unity/RapidJSON-src" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Debug-Unity/RapidJSON-src/thirdparty/gtest" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Mac-Release-Unreal/RapidJSON-src" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/out/build/x64-Mac-Release-Unreal/RapidJSON-src/thirdparty/gtest" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/test/gtest" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/wrappers/python/pybind11" vcs="Git" />
   </component>

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/PolygonMesh/CityObjectList.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/PolygonMesh/CityObjectList.cs
@@ -27,6 +27,11 @@ namespace PLATEAU.PolygonMesh
             };
         }
 
+        public int[] ToArray()
+        {
+            return new[] { PrimaryIndex, AtomicIndex };
+        }
+
         public override int GetHashCode()
         {
             return PrimaryIndex * 10000 + AtomicIndex;


### PR DESCRIPTION


## 確認方法
Unityで同一マテリアルへの変換→属性情報で色分けすると情報が欠けていたのが分かる。それを解決。

