### PR TITLE
#260 SDKで書き出したFBXが一緒に書き出したテクスチャを参照していない

### DIFF
--- a/examples/export_fbx/export_fbx.cpp
+++ b/examples/export_fbx/export_fbx.cpp
@@ -67,11 +67,12 @@ int main() {
         const auto destination = fs::path(".").string();
         const auto gml_file_name = fs::path(gml_file_path).filename().string();
         auto base_obj_name = fs::path(gml_file_name).replace_extension(".fbx").string();
-        const auto gltf_file_path = fs::path(destination).append(base_obj_name).make_preferred().string();
-        plateau::meshWriter::FbxWriteOptions options;
-        options.file_format = plateau::meshWriter::FbxFileFormat::ASCII;
-        auto result = plateau::meshWriter::FbxWriter().write(gltf_file_path , *model, options);
+        const auto fbx_file_path = fs::path(destination).append(base_obj_name).make_preferred().string();
 
+        plateau::meshWriter::FbxWriteOptions options;
+        options.file_format = plateau::meshWriter::FbxFileFormat::Binary;
+        options.coordinate_system = plateau::geometry::CoordinateSystem::ENU;
+        auto result = plateau::meshWriter::FbxWriter().write(fbx_file_path, *model, options);
     }
     catch (std::exception& e) {
         std::cout << e.what() << std::endl;

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -88,7 +88,7 @@ namespace plateau::meshWriter {
 
             for (int i = 0; i < model.getRootNodeCount(); ++i) {
                 const auto& node = model.getRootNodeAt(i);
-                processNodeRecursive(node, fbx_scene->GetRootNode(), fbx_scene);
+                processNodeRecursive(node, fbx_scene->GetRootNode(), fbx_scene, fs::absolute(path).u8string());
             }
 
             const auto exporter = FbxExporter::Create(manager_, "");
@@ -107,14 +107,14 @@ namespace plateau::meshWriter {
             exporter->Destroy();
 
             // テクスチャファイルコピー
-            for (const auto& texture : required_textures_) {
-                copyTexture(fs::absolute(path).u8string(), texture);
+            for (const auto& texture_path : required_textures_) {
+                copyTexture(fs::absolute(path).u8string(), texture_path);
             }
 
             return true;
         }
 
-        void processNodeRecursive(const polygonMesh::Node& node, FbxNode* parent_fbx_node, FbxScene* fbx_scene) {
+        void processNodeRecursive(const polygonMesh::Node& node, FbxNode* parent_fbx_node, FbxScene* fbx_scene, const std::string& fbx_path) {
             const auto fbx_node = FbxNode::Create(fbx_scene, node.getName().c_str());
             parent_fbx_node->AddChild(fbx_node);
 
@@ -137,15 +137,15 @@ namespace plateau::meshWriter {
 
             const auto mesh = node.getMesh();
             if (mesh != nullptr)
-                addMesh(*mesh, fbx_scene, fbx_node);
+                addMesh(*mesh, fbx_scene, fbx_node, fbx_path);
 
             for (size_t i = 0; i < node.getChildCount(); ++i) {
                 const auto& child_node = node.getChildAt(i);
-                processNodeRecursive(child_node, fbx_node, fbx_scene);
+                processNodeRecursive(child_node, fbx_node, fbx_scene, fbx_path);
             }
         }
 
-        void addMesh(const polygonMesh::Mesh& mesh, FbxScene* fbx_scene, FbxNode* fbx_node) {
+        void addMesh(const polygonMesh::Mesh& mesh, FbxScene* fbx_scene, FbxNode* fbx_node, const std::string& fbx_path) {
             const auto fbx_mesh = FbxMesh::Create(fbx_scene, "");
 
             // Create control points.
@@ -245,7 +245,10 @@ namespace plateau::meshWriter {
                         if (FbxColorProperty.IsValid()) {
                             //Create a fbx property
                             FbxFileTexture* lTexture = FbxFileTexture::Create(fbx_scene, fs::u8path(texture_path).filename().u8string().c_str());
-                            lTexture->SetFileName(texture_path.c_str());
+                            auto dst_path = fs::u8path(fbx_path).parent_path();
+                            dst_path /= fs::u8path(texture_path).parent_path().filename();
+                            dst_path /= fs::u8path(texture_path).filename();
+                            lTexture->SetFileName(dst_path.u8string().c_str());
                             lTexture->SetTextureUse(FbxTexture::eStandard);
                             lTexture->SetMappingType(FbxTexture::eUV);
                             lTexture->ConnectDstProperty(FbxColorProperty);


### PR DESCRIPTION
## 関連リンク
<!-- libcitygmlのPR等、関連するPRがあれば書く。 -->

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
FBXエクスポート時にプラグイン側のテクスチャを参照していましたが、エクスポートフォルダ内にコピーされるテクスチャを参照するように変更しました。

## レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
FBXをエクスポート後、Blenderにインポートしてテクスチャが表示されるか確認する。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
