### PR TITLE
Descriptionノードが属性情報の入れ子内に存在するケースに対応。gml名が大文字で始まるケースに対応。

### DIFF
--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/CityGML/NativeAttributeValueTests.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/CityGML/NativeAttributeValueTests.cs
@@ -81,12 +81,10 @@ namespace PLATEAU.Test.CityGML
         [TestMethod]
         public void AsBool_Returns_GML_Value()
         {
-            const string parentKey = "uro:buildingDetails";
-            const string childKey = "energy:isHeated";
             const bool valueInGmlFile = true;
-            var parentVal = attrMap[parentKey];
+            var parentVal = attrMap["uro:buildingDetails"].AsAttrSet["uro:BuildingDetails"];
             var children = parentVal.AsAttrSet;
-            bool actualVal = children[childKey].AsBool;
+            bool actualVal = children["energy:isHeated"].AsBool;
             Assert.AreEqual(valueInGmlFile, actualVal);
         }
     }


### PR DESCRIPTION
千代田区の53394600_bldg_6697_op.gmlにおいて、建物の属性情報について、隅田川と高潮の両方の浸水に関する属性情報があるはずだったが、片方しか出てこなかった。原因はuro:descriptionノードが入れ子になるケースに対応できていなかったこと、gml名が大文字で始まるケースが無視されていたことだった。このプルリクで解決。