### PR TITLE
Minor grid code fix

### DIFF
--- a/include/plateau/dataset/i_dataset_accessor.h
+++ b/include/plateau/dataset/i_dataset_accessor.h
@@ -132,7 +132,7 @@ namespace plateau::dataset {
         /**
          * \brief 都市モデルデータが存在する地域メッシュのリストを取得します。
          */
-        virtual std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() = 0;
+        virtual const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() = 0;
 
         virtual TVec3d calculateCenterPoint(const plateau::geometry::GeoReference& geo_reference) = 0;
 

--- a/src/dataset/local_dataset_accessor.cpp
+++ b/src/dataset/local_dataset_accessor.cpp
@@ -301,7 +301,7 @@ namespace plateau::dataset {
         return fs::relative(fs::u8path(path).make_preferred(), fs::u8path(udx_path_)).make_preferred().string();
     }
 
-    std::set<std::shared_ptr<GridCode>, GridCodeComparator>& LocalDatasetAccessor::getGridCodes() {
+    const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& LocalDatasetAccessor::getGridCodes() {
         if (grid_codes_.empty()) {
             for (const auto& [_, files]: files_) {
                 for (const auto& file: files) {

--- a/src/dataset/local_dataset_accessor.h
+++ b/src/dataset/local_dataset_accessor.h
@@ -68,7 +68,7 @@ namespace plateau::dataset {
         /**
          * \brief 都市モデルデータが存在するGridCodeのリストを取得します。
          */
-        std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() override;
+        const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() override;
 
         std::string getRelativePath(const std::string& path) const;
         std::string getU8RelativePath(const std::string& path) const;

--- a/src/dataset/server_dataset_accessor.cpp
+++ b/src/dataset/server_dataset_accessor.cpp
@@ -21,7 +21,7 @@ namespace plateau::dataset {
         grid_codes_.clear();
     }
 
-    std::set<std::shared_ptr<GridCode>, GridCodeComparator>& ServerDatasetAccessor::getGridCodes() {
+    const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& ServerDatasetAccessor::getGridCodes() {
         if (grid_codes_.empty()) {
             for (const auto& [_, files] : dataset_files_) {
                 for (const auto& file : files) {

--- a/src/dataset/server_dataset_accessor.h
+++ b/src/dataset/server_dataset_accessor.h
@@ -18,7 +18,7 @@ namespace plateau::dataset {
 
         void loadFromServer();
 
-        std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() override;
+        const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() override;
         std::shared_ptr<std::vector<GmlFile>> getGmlFiles(PredefinedCityModelPackage package) override;
         void getGmlFiles(PredefinedCityModelPackage package_flags, std::vector<GmlFile>& out_gml_files) override;
 

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/DatasetAccessor.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/DatasetAccessor.cs
@@ -41,6 +41,10 @@ namespace PLATEAU.Dataset
             return GetGmlFiles((PredefinedCityModelPackage)allPackages);
         }
 
+        /// <summary>
+        /// C++側のvectorとしてのGridCodeを返します。
+        /// 注意：受け取る側でusingを付けるなど、廃棄されるようにしてください。
+        /// </summary>
         public NativeVectorGridCode GridCodes
         {
             get
@@ -79,7 +83,7 @@ namespace PLATEAU.Dataset
             var nativeGridCodes = NativeVectorGridCode.Create();
             foreach (var gridCode in gridCodes)
             {
-                nativeGridCodes.Add(gridCode);
+                nativeGridCodes.AddCopyOf(gridCode);
             }
 
             var result = NativeMethods.plateau_i_dataset_accessor_filter_by_grid_codes(

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/GmlFile.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/GmlFile.cs
@@ -81,6 +81,7 @@ namespace PLATEAU.Dataset
         /// GMLファイルのGridCodeを返します。
         /// ただし、誤った形式のGMLファイル名である等の理由でGridCodeを読み取れなかった場合は
         /// 戻り値の isValid が false になります。
+        /// 戻り値が解放されるようにするためにusingを付けてください。
         /// </summary>
         public GridCode GridCode
         {
@@ -89,6 +90,7 @@ namespace PLATEAU.Dataset
                 ThrowIfDisposed();
                 var gridCodePtr = DLLUtil.GetNativeValue<IntPtr>(Handle,
                     NativeMethods.plateau_gml_file_get_grid_code);
+                // gridCodePtrの寿命管理はC++側に任せるのでここでは解放しませんが、copiedはC#から解放する必要があります。
                 var copied =  GridCode.CopyFrom(gridCodePtr);
                 return copied;
             }

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/MeshCode.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/Dataset/MeshCode.cs
@@ -21,51 +21,5 @@ namespace PLATEAU.Dataset
         public readonly int Level;
         [MarshalAs(UnmanagedType.U1)] private readonly bool isValid;
 
-        private static bool getHalfMeshNumber(out int num, int row, int col)
-        {
-            if (row < 0 || row > 1 ||
-                col < 0 || col > 1)
-            {
-                num = 0;
-                return false;
-            }
-
-            // 番号順に左下→右下→左上→右上
-            num = row * 2 + col + 1;
-            return true;
-        }
-
-        public override string ToString()
-        {
-            // ThrowIfInvalid();
-            string secondString = Level2();
-            if (this.Level == 2)
-                return secondString;
-
-            string thirdString = secondString + $"{this.ThirdRow | 0}{this.ThirdCol | 0}";
-            if (this.Level == 3)
-                return thirdString;
-
-            getHalfMeshNumber(out int fourthNum, this.FourthRow, this.FourthCol);
-            string fourthString = thirdString + $"{fourthNum}";
-            if (this.Level == 4)
-                return fourthString;
-
-            getHalfMeshNumber(out int fifthNum, this.FifthRow, this.FifthCol);
-            string fifthString = fourthString + $"{fifthNum}";
-            return fifthString;
-        }
-
-        public string Level2()
-        {
-            // ThrowIfInvalid();
-            return $"{this.FirstRow | 00}{this.FirstCol | 00}{this.SecondRow | 0}{this.SecondCol | 0}";
-        }
-
-        public string Level3()
-        {
-            // ThrowIfInvalid();
-            return $"{Level2()}{this.ThirdRow | 0}{this.ThirdCol | 0}";
-        }
     }
 }


### PR DESCRIPTION
微修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - C#ラッパーの各プロパティやクラスに利用方法や注意点のコメントを追加・改善しました。

- **バグ修正**
  - C#ラッパーでGridCodeのコピー管理方法を改善し、メモリ管理の安全性を向上しました。

- **リファクタ**
  - C++側のグリッドコード取得メソッドの返却型をconst参照に変更し、不変性を保証しました。
  - C#のMeshCode構造体からToStringやLevel2/Level3等のメソッドを削除しました。

- **スタイル**
  - C#ラッパーのメソッド名をより明確なものに変更しました（Add → AddCopyOf）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->