### PR TITLE
GitHub ActionsのUbuntuバージョンを変更

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -89,13 +89,6 @@ runs:
         echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=cl.exe" >> $env:GITHUB_ENV
       shell: ${{ inputs.shell_type }}
 
-      # Linuxで使うコンパイラを明示(g++-9)
-    # - name: Setup Additional Cmake Options in Linux
-    #   if: runner.os == 'Linux'
-    #   run: |
-    #     echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=\"/usr/bin/g++-9\"" >> $GITHUB_ENV
-    #   shell: ${{ inputs.shell_type }}
-
     - name: Configure CMake for Unity
       run: >
         cmake

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -89,13 +89,12 @@ runs:
         echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=cl.exe" >> $env:GITHUB_ENV
       shell: ${{ inputs.shell_type }}
 
-      # Linuxで使うコンパイラを明示
+      # Linuxで使うコンパイラを明示(g++-9)
     - name: Setup Additional Cmake Options in Linux
       if: runner.os == 'Linux'
       run: |
         echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=\"/usr/bin/g++-9\"" >> $GITHUB_ENV
       shell: ${{ inputs.shell_type }}
-      # Ubuntu 18 だとデフォルトでは g++-7 になりますが、std::filesystem を使う都合上 g++-9 を指定します。
 
     - name: Configure CMake for Unity
       run: >

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -90,11 +90,11 @@ runs:
       shell: ${{ inputs.shell_type }}
 
       # Linuxで使うコンパイラを明示(g++-9)
-    - name: Setup Additional Cmake Options in Linux
-      if: runner.os == 'Linux'
-      run: |
-        echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=\"/usr/bin/g++-9\"" >> $GITHUB_ENV
-      shell: ${{ inputs.shell_type }}
+    # - name: Setup Additional Cmake Options in Linux
+    #   if: runner.os == 'Linux'
+    #   run: |
+    #     echo "ADDITIONAL_CMAKE_OPTIONS=-DCMAKE_CXX_COMPILER=\"/usr/bin/g++-9\"" >> $GITHUB_ENV
+    #   shell: ${{ inputs.shell_type }}
 
     - name: Configure CMake for Unity
       run: >

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
             arch: x86_64
           - os: macos-14
             arch: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04 # Unity LTSの対応バージョンに合わせておきます
             arch: x86_64
 
     steps:

--- a/.github/workflows/check-submodule-license.yml
+++ b/.github/workflows/check-submodule-license.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check-submodule-license:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/upload-dlls-older-visual-studio.yml
+++ b/.github/workflows/upload-dlls-older-visual-studio.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-14, ubuntu-20.04]
+        os: [windows-2019, macos-14, ubuntu-24.04] # UbuntuはUnity LTSの対応バージョンに合わせておきます
         arch: [x86_64]
         include:
           - os: macos-14
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/upload-dll
         with:
           shell_type: ${{ (runner.os == 'Windows' && 'powershell') || 'bash' }}
-          visual_studio_version: "16 2019"
+          visual_studio_version: "17 2022"
 
   # 2つ目のジョブ。
   # AndroidとiOS用にライブラリをビルド。

--- a/.github/workflows/upload-dlls-older-visual-studio.yml
+++ b/.github/workflows/upload-dlls-older-visual-studio.yml
@@ -98,7 +98,7 @@ jobs:
           mkdir -p ~/a/plateau-plugins/dynamic-libs/iOS/plateau.framework
           cp ~/a/libplateau-windows/plateau.dll ~/a/plateau-plugins/dynamic-libs/Windows/x86_64
           cp ~/a/libplateau-windows/CSharpPLATEAU.dll ~/a/plateau-plugins/dynamic-libs/ManagedDLL
-          cp ~/a/libplateau-ubuntu-20.04/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
+          cp ~/a/libplateau-ubuntu-24.04/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           cp ~/a/libplateau-macos-14-x86_64/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
           cp ~/a/libplateau-macos-14-arm64/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/arm64
           cp ~/a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
@@ -110,7 +110,7 @@ jobs:
           mkdir -p ~/a/plateau-plugins/static-libs/linux
           mkdir -p ~/a/plateau-plugins/static-libs/macos
           cp ~/a/libplateau-windows/*.lib ~/a/plateau-plugins/static-libs/windows
-          cp ~/a/libplateau-ubuntu-20.04/*.a ~/a/plateau-plugins/static-libs/linux
+          cp ~/a/libplateau-ubuntu-24.04/*.a ~/a/plateau-plugins/static-libs/linux
           cp ~/a/libplateau-macos-14-x86_64/*.a ~/a/plateau-plugins/static-libs/macos/x86_64
           cp ~/a/libplateau-macos-14-arm64/*.a ~/a/plateau-plugins/static-libs/macos/arm64
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -101,7 +101,7 @@ jobs:
           mkdir -p ~/a/plateau-plugins/dynamic-libs/iOS/plateau.framework
           cp ~/a/libplateau-windows/plateau.dll ~/a/plateau-plugins/dynamic-libs/Windows/x86_64
           cp ~/a/libplateau-windows/CSharpPLATEAU.dll ~/a/plateau-plugins/dynamic-libs/ManagedDLL
-          cp ~/a/libplateau-ubuntu-20.04/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
+          cp ~/a/libplateau-ubuntu-24.04/*.so ~/a/plateau-plugins/dynamic-libs/Linux/x86_64
           cp ~/a/libplateau-macos-14-x86_64/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/x86_64
           cp ~/a/libplateau-macos-14-arm64/*.dylib ~/a/plateau-plugins/dynamic-libs/MacOS/arm64
           cp ~/a/libplateau-android-dll/libplateau.so ~/a/plateau-plugins/dynamic-libs/Android
@@ -114,7 +114,7 @@ jobs:
           mkdir -p ~/a/plateau-plugins/static-libs/macos/x86_64
           mkdir -p ~/a/plateau-plugins/static-libs/macos/arm64
           cp ~/a/libplateau-windows/*.lib ~/a/plateau-plugins/static-libs/windows
-          cp ~/a/libplateau-ubuntu-20.04/*.a ~/a/plateau-plugins/static-libs/linux
+          cp ~/a/libplateau-ubuntu-24.04/*.a ~/a/plateau-plugins/static-libs/linux
           cp ~/a/libplateau-macos-14-x86_64/*.a ~/a/plateau-plugins/static-libs/macos/x86_64
           cp ~/a/libplateau-macos-14-arm64/*.a ~/a/plateau-plugins/static-libs/macos/arm64
 

--- a/.github/workflows/upload-dlls.yml
+++ b/.github/workflows/upload-dlls.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-14, ubuntu-20.04]
+        os: [windows-2022, macos-14, ubuntu-24.04] # UbuntuはUnity LTSの対応バージョンに合わせておきます
         arch: [x86_64]
         include:
           - os: macos-14

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ fbx_sdk は Autodesk社が公開するSDKです。これは自由に製品に組
 ### Linuxでの手動ビルド
 利用する Linux は、Unityの対応OSに合わせて Ubuntu 24.04 とします。
 #### C++のビルド
-* Ubuntu 20 はデフォルトでは git lfs がないので、`sudo apt install git-lfs` します。
+* Ubuntuでgit lfsを使うために`sudo apt install git-lfs` します。
 * OpenGL API が必要なので、なければ以下のコマンドでインストールします。
 ```
 sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ fbx_sdk は Autodesk社が公開するSDKです。これは自由に製品に組
 * C#ユニットテストも合わせて実行可能です。
 
 ### Linuxでの手動ビルド
-利用する Linux は、Unityの対応OSに合わせて Ubuntu 20.04 とします。
+利用する Linux は、Unityの対応OSに合わせて Ubuntu 24.04 とします。
 #### C++のビルド
 * Ubuntu 20 はデフォルトでは git lfs がないので、`sudo apt install git-lfs` します。
 * OpenGL API が必要なので、なければ以下のコマンドでインストールします。

--- a/include/plateau/dataset/city_model_package.h
+++ b/include/plateau/dataset/city_model_package.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace plateau::dataset {
     /**


### PR DESCRIPTION
前：GitHub ActionsのUbuntuランナーのバージョンが古いためにCIが落ちていた。  
今：Ubuntuバージョンを更新して落ちないようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - READMEのLinux推奨バージョンをUbuntu 24.04に更新しました。

- **チョア**
  - ビルドやCIワークフローで使用するUbuntuバージョンを20.04から24.04に変更しました。
  - Visual Studioのバージョン指定を新しくしました。
  - サブモジュールのglTF-SDK参照先を更新しました。
  - Linuxビルド環境でのC++コンパイラ設定の一部を削除しました。

- **リファクタ**
  - 固定幅整数型利用のため、ヘッダーファイルに<cstdint>のインクルードを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->