### PR TITLE
FBXエクスポートの座標系バグ

### DIFF
--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -44,34 +44,6 @@ namespace plateau::meshWriter {
             ios->SetBoolProp(EXP_FBX_GLOBAL_SETTINGS, true);
             ios->SetBoolProp(EXP_ASCIIFBX, options.file_format == FbxFileFormat::ASCII);
             const auto fbx_scene = FbxScene::Create(manager_, "");
-            FbxAxisSystem axis_system;
-            switch (options.coordinate_system) {
-            case geometry::CoordinateSystem::ENU:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eRightHanded);
-                break;
-            case geometry::CoordinateSystem::ESU:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eLeftHanded);
-                break;
-            case geometry::CoordinateSystem::WUN:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eYAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eRightHanded);
-                break;
-            case geometry::CoordinateSystem::EUN:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eYAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eLeftHanded);
-                break;
-            }
-            axis_system.ConvertScene(fbx_scene);
 
             // create scene info
             FbxDocumentInfo* SceneInfo = FbxDocumentInfo::Create(manager_, "SceneInfo");


### PR DESCRIPTION
## 関連リンク
(https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/issues/481)

## 実装内容
FBX Exportの座標変換が２重変換になっているため変換処理削除。

## レビュー前確認項目
FBX Export時の軸変換がENU/WUNで正常に行われる。
SDK v2.3.2での Export結果と同様になる。

## マージ前確認項目
- [ ] 自動ビルド・テストが通っていること
- [ ] Squash and Mergeが選択されていること
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->

## 動作確認
Unity/Unrealで、FBX Export時の軸変換がENU/WUNで正常に行われる。
Unity SDK v2.3.2での Export結果と同様になる。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - FBXシーンの座標系設定に関する処理を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->