### PR TITLE
FBXエクスポート時にfbxファイルに座標軸を書き出すように

### DIFF
--- a/src/geometry/geo_reference.cpp
+++ b/src/geometry/geo_reference.cpp
@@ -86,7 +86,7 @@ namespace plateau::geometry {
             // WUN → ENU の式は 逆変換 ENU → WUN と同じです。
             return { -vertex.x, vertex.z, vertex.y };
         case CoordinateSystem::ESU:
-            // EUN → ESU の式は 逆変換 ESU → EUN と同じです。
+            // ENU → ESU の式は 逆変換 ESU → ENU と同じです。
             return { vertex.x, -vertex.y, vertex.z };
         case CoordinateSystem::EUN:
             // EUN → ENU の式は 逆変換 ENU → EUN と同じです。

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -44,34 +44,6 @@ namespace plateau::meshWriter {
             ios->SetBoolProp(EXP_FBX_GLOBAL_SETTINGS, true);
             ios->SetBoolProp(EXP_ASCIIFBX, options.file_format == FbxFileFormat::ASCII);
             const auto fbx_scene = FbxScene::Create(manager_, "");
-            FbxAxisSystem axis_system;
-            switch (options.coordinate_system) {
-            case geometry::CoordinateSystem::ENU:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eRightHanded);
-                break;
-            case geometry::CoordinateSystem::ESU:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eLeftHanded);
-                break;
-            case geometry::CoordinateSystem::WUN:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eYAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eRightHanded);
-                break;
-            case geometry::CoordinateSystem::EUN:
-                axis_system = FbxAxisSystem(
-                    FbxAxisSystem::EUpVector::eYAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
-                    FbxAxisSystem::eLeftHanded);
-                break;
-            }
-            axis_system.ConvertScene(fbx_scene);
 
             // create scene info
             FbxDocumentInfo* SceneInfo = FbxDocumentInfo::Create(manager_, "SceneInfo");

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -46,17 +46,19 @@ namespace plateau::meshWriter {
             const auto fbx_scene = FbxScene::Create(manager_, "");
 
             FbxAxisSystem axis_system;
+            // FBXのデファクトは右手座標系です。
+            // 左手座標系ではUnityやUEで正しく読み込めないことがあるため非推奨です。
             switch (options.coordinate_system) {
             case geometry::CoordinateSystem::ENU:
                 axis_system = FbxAxisSystem(
                     FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::EFrontVector::eParityOdd,
                     FbxAxisSystem::eRightHanded);
                 break;
             case geometry::CoordinateSystem::ESU:
                 axis_system = FbxAxisSystem(
                     FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::EFrontVector::eParityOdd,
                     FbxAxisSystem::eLeftHanded);
                 break;
             case geometry::CoordinateSystem::WUN:
@@ -68,7 +70,7 @@ namespace plateau::meshWriter {
             case geometry::CoordinateSystem::EUN:
                 axis_system = FbxAxisSystem(
                     FbxAxisSystem::EUpVector::eYAxis,
-                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::EFrontVector::eParityOdd,
                     FbxAxisSystem::eLeftHanded);
                 break;
             }

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -52,8 +52,8 @@ namespace plateau::meshWriter {
             case geometry::CoordinateSystem::ENU:
                 axis_system = FbxAxisSystem(
                     FbxAxisSystem::EUpVector::eZAxis,
-                    FbxAxisSystem::EFrontVector::eParityOdd,
-                    FbxAxisSystem::eRightHanded);
+                    FbxAxisSystem::EFrontVector::eParityOdd, // X,Y,ZからUp軸を除いて、残った2軸のうち前者ならParityEven, 後者ならParityOdd
+                    FbxAxisSystem::eRightHanded); // フレミングの法則の要領で中指を折ったとき、親指がX、人差し指がY、中指がZ。左右どちらの手に合うか。
                 break;
             case geometry::CoordinateSystem::ESU:
                 axis_system = FbxAxisSystem(
@@ -74,6 +74,11 @@ namespace plateau::meshWriter {
                     FbxAxisSystem::eLeftHanded);
                 break;
             }
+            // 座標軸の向きをFBXファイルに書き込みます。
+            // これを確認するには、FBXをASCIIフォーマットで出力してテキストエディタで開き、
+            // GlobalSettingsのPropertiesのAxis系プロパティを確認します。
+            // これにより、どの座標軸で書き出したとしてもアプリケーションにFBXをインポートするときに向き補正が働き、
+            // 同じ向きに読み込めるはずです（非推奨の左手座標系は除く）。
             fbx_scene->GetGlobalSettings().SetAxisSystem(axis_system);
 
             // create scene info

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -63,7 +63,7 @@ namespace plateau::meshWriter {
                 axis_system = FbxAxisSystem(
                     FbxAxisSystem::EUpVector::eYAxis,
                     FbxAxisSystem::EFrontVector::eParityOdd,
-                    FbxAxisSystem::eLeftHanded);
+                    FbxAxisSystem::eRightHanded);
                 break;
             case geometry::CoordinateSystem::EUN:
                 axis_system = FbxAxisSystem(

--- a/src/mesh_writer/fbx_writer.cpp
+++ b/src/mesh_writer/fbx_writer.cpp
@@ -45,6 +45,35 @@ namespace plateau::meshWriter {
             ios->SetBoolProp(EXP_ASCIIFBX, options.file_format == FbxFileFormat::ASCII);
             const auto fbx_scene = FbxScene::Create(manager_, "");
 
+            FbxAxisSystem axis_system;
+            switch (options.coordinate_system) {
+            case geometry::CoordinateSystem::ENU:
+                axis_system = FbxAxisSystem(
+                    FbxAxisSystem::EUpVector::eZAxis,
+                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::eRightHanded);
+                break;
+            case geometry::CoordinateSystem::ESU:
+                axis_system = FbxAxisSystem(
+                    FbxAxisSystem::EUpVector::eZAxis,
+                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::eLeftHanded);
+                break;
+            case geometry::CoordinateSystem::WUN:
+                axis_system = FbxAxisSystem(
+                    FbxAxisSystem::EUpVector::eYAxis,
+                    FbxAxisSystem::EFrontVector::eParityOdd,
+                    FbxAxisSystem::eLeftHanded);
+                break;
+            case geometry::CoordinateSystem::EUN:
+                axis_system = FbxAxisSystem(
+                    FbxAxisSystem::EUpVector::eYAxis,
+                    FbxAxisSystem::EFrontVector::eParityEven,
+                    FbxAxisSystem::eLeftHanded);
+                break;
+            }
+            fbx_scene->GetGlobalSettings().SetAxisSystem(axis_system);
+
             // create scene info
             FbxDocumentInfo* SceneInfo = FbxDocumentInfo::Create(manager_, "SceneInfo");
             fbx_scene->SetSceneInfo(SceneInfo);

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/MeshWriter/FbxWriterTest.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU.Test/MeshWriter/FbxWriterTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PLATEAU.Geometries;
 using PLATEAU.MeshWriter;
 using PLATEAU.Test.CityGML;
 using PLATEAU.Test.GeometryModel;
@@ -19,7 +20,7 @@ namespace PLATEAU.Test.MeshWriter
             string gmlPath = TestUtil.GetGmlPath(TestUtil.GmlFileCase.Simple);
             string fbxFileName = Path.GetFileNameWithoutExtension(gmlPath) + ".fbx";
             string fbxPath = Path.Combine(testDir, fbxFileName);
-            var option = new FbxWriteOptions(FbxFileFormat.Binary);
+            var option = new FbxWriteOptions(FbxFileFormat.Binary, CoordinateSystem.ENU);
             
             bool isSucceed = FbxWriter.Write(fbxPath, model, option);
             

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/MeshWriter/FbxWriter.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/MeshWriter/FbxWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using PLATEAU.Geometries;
 using PLATEAU.Interop;
 using PLATEAU.PolygonMesh;
 
@@ -9,10 +10,12 @@ namespace PLATEAU.MeshWriter
     public struct FbxWriteOptions
     {
         public FbxFileFormat FileFormat;
+        public CoordinateSystem CoordinateSystem;
 
-        public FbxWriteOptions(FbxFileFormat fileFormat)
+        public FbxWriteOptions(FbxFileFormat fileFormat, CoordinateSystem coordinateSystem)
         {
             this.FileFormat = fileFormat;
+            this.CoordinateSystem = coordinateSystem;
         }
     }
     


### PR DESCRIPTION
Unityで右手座標系でFBXを書き出す→Unityに読み込み時、FBXの座標軸方向の情報により正しい情報で読み込まれます

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - FBXエクスポート時のオプションに「座標系」の指定が追加されました。

- **ドキュメント**
  - ENUとESU間の座標変換に関するコメント表記を修正しました。
  - FBXの座標系設定に関する説明コメントを追加しました。

- **リファクタ**
  - FBXエクスポート時の座標系設定方法が変更され、シーンのグローバル設定に直接適用されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->