### PR TITLE
MeshExtractorをログ出力に対応させ、各段階の処理時間をログに出すようにした

### DIFF
--- a/include/plateau/polygon_mesh/mesh_extractor.h
+++ b/include/plateau/polygon_mesh/mesh_extractor.h
@@ -6,6 +6,7 @@
 #include <plateau/polygon_mesh/mesh_extract_options.h>
 #include <plateau/geometry/geo_coordinate.h>
 #include "citygml/citymodel.h"
+#include "citygml/citygmllogger.h"
 #include "model.h"
 
 namespace plateau::polygonMesh {
@@ -33,6 +34,7 @@ namespace plateau::polygonMesh {
          * 生ポインタのdeleteはDLLの利用者の責任です。
          */
         static void extract(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options);
+        static void extract(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options, const std::shared_ptr<citygml::CityGMLLogger>& logger);
 
         /**
          * CityModelから範囲内のModelを取り出します。
@@ -43,6 +45,7 @@ namespace plateau::polygonMesh {
          * CityModelから範囲内のModelを取り出します。
          */
         static void extractInExtents(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options, const std::vector<plateau::geometry::Extent>& extents);
+        static void extractInExtents(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options, const std::vector<plateau::geometry::Extent>& extents, const std::shared_ptr<citygml::CityGMLLogger>& logger);
 
         /**
          * 引数で与えられた LOD の主要地物について、次を判定して bool で返します。

--- a/src/c_wrapper/mesh_extractor_c.cpp
+++ b/src/c_wrapper/mesh_extractor_c.cpp
@@ -2,6 +2,7 @@
 #include "city_model_c.h"
 #include <plateau/polygon_mesh/mesh_extractor.h>
 #include <plateau/geometry/geo_coordinate.h>
+#include <plateau_dll_logger.h>
 
 using namespace libplateau;
 using namespace plateau::polygonMesh;
@@ -38,6 +39,25 @@ extern "C"{
             Model* const out_model) {
         API_TRY{
             MeshExtractor::extractInExtents(*out_model, city_model_handle->getCityModel(), options, *extents);
+            return APIResult::Success;
+        }
+        API_CATCH;
+        return APIResult::ErrorUnknown;
+    }
+
+    LIBPLATEAU_C_EXPORT APIResult LIBPLATEAU_C_API plateau_mesh_extractor_extract_in_extents_with_log(
+            const CityModelHandle* const city_model_handle,
+            const MeshExtractOptions options,
+            const std::vector<plateau::geometry::Extent>* extents,
+            Model* const out_model,
+            const DllLogLevel logLevel,
+            LogCallbackFuncPtr logErrorCallback,
+            LogCallbackFuncPtr logWarnCallback,
+            LogCallbackFuncPtr logInfoCallback) {
+        API_TRY{
+            auto logger = std::make_shared<PlateauDllLogger>(logLevel);
+            logger->setLogCallbacks(logErrorCallback, logWarnCallback, logInfoCallback);
+            MeshExtractor::extractInExtents(*out_model, city_model_handle->getCityModel(), options, *extents, logger);
             return APIResult::Success;
         }
         API_CATCH;

--- a/src/polygon_mesh/mesh_extractor.cpp
+++ b/src/polygon_mesh/mesh_extractor.cpp
@@ -8,6 +8,9 @@
 #include <plateau/polygon_mesh/polygon_mesh_utils.h>
 #include <plateau/dataset/gml_file.h>
 #include <plateau/texture/texture_packer.h>
+#include <chrono>
+
+#include "plateau_dll_logger.h"
 
 namespace {
     using namespace plateau;
@@ -16,6 +19,34 @@ namespace {
     using namespace texture;
     using namespace citygml;
     namespace fs = std::filesystem;
+
+    class Stopwatch {
+    public:
+        Stopwatch(std::shared_ptr<citygml::CityGMLLogger> logger, const std::string& task_name)
+            : logger_(std::move(logger)), task_name_(task_name) {
+            total_start_time_ = std::chrono::steady_clock::now();
+            stage_start_time_ = total_start_time_;
+            logger_->log(citygml::CityGMLLogger::LOGLEVEL::LL_INFO, task_name_ + " start.");
+        }
+
+        ~Stopwatch() {
+            const auto total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - total_start_time_).count();
+            logger_->log(citygml::CityGMLLogger::LOGLEVEL::LL_INFO, task_name_ + " finished. Total: " + std::to_string(total_duration) + "ms");
+        }
+
+        void log_stage(const std::string& stage_name) {
+            const auto end_time = std::chrono::steady_clock::now();
+            const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - stage_start_time_).count();
+            logger_->log(citygml::CityGMLLogger::LOGLEVEL::LL_INFO, "  " + stage_name + " : " + std::to_string(duration) + "ms");
+            stage_start_time_ = end_time;
+        }
+
+    private:
+        std::shared_ptr<citygml::CityGMLLogger> logger_;
+        std::string task_name_;
+        std::chrono::steady_clock::time_point total_start_time_;
+        std::chrono::steady_clock::time_point stage_start_time_;
+    };
 
     bool shouldSkipCityObj(const CityObject& city_obj, const MeshExtractOptions& options, const std::vector<geometry::Extent>& extents) {
 
@@ -36,14 +67,25 @@ namespace {
     void extractInner(
         Model& out_model, const CityModel& city_model,
         const MeshExtractOptions& options,
-        const std::vector<geometry::Extent>& extents_before_adjust) {
+        const std::vector<geometry::Extent>& extents_before_adjust,
+        std::shared_ptr<citygml::CityGMLLogger> logger) {
 
-        if (options.max_lod < options.min_lod) throw std::logic_error("Invalid LOD range.");
+        if (logger == nullptr) {
+            logger = std::make_shared<PlateauDllLogger>();
+        }
+
+        Stopwatch stopwatch(logger, "MeshExtractor");
+
+        if (options.max_lod < options.min_lod) {
+            logger->log(citygml::CityGMLLogger::LOGLEVEL::LL_ERROR, "Invalid LOD range.");
+            throw std::logic_error("Invalid LOD range.");
+        }
 
         const auto geo_reference = geometry::GeoReference(options.coordinate_zone_id, options.reference_point, options.unit_scale, options.mesh_axes);
 
         // 範囲の境界上にある地物を取り逃さないように、範囲を少し広げます。
         auto extents = MeshExtractor::extendExtents(extents_before_adjust, 1.2f);
+        stopwatch.log_stage("Initialize");
 
         // rootNode として LODノード を作ります。
         for (unsigned lod = options.min_lod; lod <= options.max_lod; lod++) {
@@ -143,14 +185,17 @@ namespace {
 
             out_model.addNode(std::move(lod_node));
         }
+        stopwatch.log_stage("LOD loop");
         out_model.eraseEmptyNodes();
         out_model.assignNodeHierarchy();
+        stopwatch.log_stage("Node arrange");
 
         // テクスチャを結合します。
         if (options.enable_texture_packing) {
             TexturePacker packer(options.texture_packing_resolution, options.texture_packing_resolution);
             packer.process(out_model);
         }
+        stopwatch.log_stage("Texture packing");
 
         // 現在の都市モデルが地形であるなら、衛星写真または地図用のUVを付与し、地図タイルをダウンロードします。
         auto package = GmlFile(city_model.getGmlPath()).getPackage();
@@ -158,8 +203,9 @@ namespace {
             const auto gml_path = fs::u8path(city_model.getGmlPath());
             const auto map_download_dest = gml_path.parent_path() / (gml_path.filename().u8string() + "_map");
             MapAttacher().attach(out_model, options.map_tile_url, map_download_dest, options.map_tile_zoom_level,
-                                geo_reference);
+                                 geo_reference);
         }
+        stopwatch.log_stage("Map attach");
     }
 }
 
@@ -173,7 +219,11 @@ namespace plateau::polygonMesh {
 
     void MeshExtractor::extract(Model& out_model, const CityModel& city_model,
                                 const MeshExtractOptions& options) {
-        extractInner(out_model, city_model, options, { plateau::geometry::Extent::all() });
+        extractInner(out_model, city_model, options, { plateau::geometry::Extent::all() }, nullptr);
+    }
+
+    void MeshExtractor::extract(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options, const std::shared_ptr<citygml::CityGMLLogger>& logger) {
+        extractInner(out_model, city_model, options, { plateau::geometry::Extent::all() }, logger);
     }
 
     std::shared_ptr<Model> MeshExtractor::extractInExtents(
@@ -190,7 +240,11 @@ namespace plateau::polygonMesh {
         const MeshExtractOptions& options,
         const std::vector<plateau::geometry::Extent>& extents) {
 
-        extractInner(out_model, city_model, options, extents);
+        extractInner(out_model, city_model, options, extents, nullptr);
+    }
+
+    void MeshExtractor::extractInExtents(Model& out_model, const citygml::CityModel& city_model, const MeshExtractOptions& options, const std::vector<plateau::geometry::Extent>& extents, const std::shared_ptr<citygml::CityGMLLogger>& logger) {
+        extractInner(out_model, city_model, options, extents, logger);
     }
 
 

--- a/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/PolygonMesh/MeshExtractor.cs
+++ b/wrappers/csharp/LibPLATEAU.NET/CSharpPLATEAU/PolygonMesh/MeshExtractor.cs
@@ -32,16 +32,22 @@ namespace PLATEAU.PolygonMesh
         /// 結果は <paramref name="outModel"/> に格納されます。
         /// 通常、<paramref name="outModel"/> には new したばかりの Model を渡してください。
         /// </summary>
-        public static void ExtractInExtents(ref Model outModel, CityModel cityModel, MeshExtractOptions options, List<Extent> extents)
+        public static void ExtractInExtents(ref Model outModel, CityModel cityModel, MeshExtractOptions options, List<Extent> extents,
+            LogCallbacks logCallbacks = null, DllLogLevel logLevel = DllLogLevel.Error)
         {
+            if (logCallbacks == null)
+            {
+                logCallbacks = LogCallbacks.StdOut;
+            }
             var nativeExtents = NativeVectorExtent.Create();
             foreach (var extent in extents)
             {
                 nativeExtents.Add(extent);
             }
 
-            var result = NativeMethods.plateau_mesh_extractor_extract_in_extents(
-                cityModel.Handle, options, nativeExtents.Handle, outModel.Handle
+            var result = NativeMethods.plateau_mesh_extractor_extract_in_extents_with_log(
+                cityModel.Handle, options, nativeExtents.Handle, outModel.Handle, logLevel,
+                logCallbacks.LogErrorFuncPtr, logCallbacks.LogWarnFuncPtr, logCallbacks.LogInfoFuncPtr
             );
             DLLUtil.CheckDllError(result);
         }
@@ -60,6 +66,18 @@ namespace PLATEAU.PolygonMesh
                 MeshExtractOptions options,
                 [In] IntPtr extentsPtr,
                 [In] IntPtr outModelPtr);
+            
+            [DllImport(DLLUtil.DllName)]
+            internal static extern APIResult plateau_mesh_extractor_extract_in_extents_with_log(
+                [In] IntPtr cityModelPtr,
+                MeshExtractOptions options,
+                [In] IntPtr extentsPtr,
+                [In] IntPtr outModelPtr,
+                DllLogLevel logLevel,
+                [In] IntPtr logErrorCallback,
+                [In] IntPtr logWarnCallback,
+                [In] IntPtr logInfoCallback
+                );
         }
     }
 }


### PR DESCRIPTION


## ✅ レビュー前確認項目
- [ ] 自動ビルド・テストが通っていること

## ✅ マージ前確認項目
- [ ] (libcitygmlの変更がある場合)libcitygmlがmasterの最新版になっていること
<!--
 libcitygmlの変更がある場合、以下の手順でlibcitygmlのPRを先にマージしてからsubmoduleをmasterに更新する。
1. libcitygmlのPRをmasterにマージ
2. 以下のコマンドでsubmoduleをmasterに更新
```
# libcitygmlをmasterの最新版にする
cd 3rdparty/libcitygml
git checkout master
git pull

# submoduleを更新する
cd ../..
git add 3rdparty/libcitygml
git commit -m "Update submodule"
git push origin {ブランチ名}
```
-->


<!-- 社内の人向け: 以下の項目は、開発当初のストーリー設計書通りであれば省略可能です。
                 設計に変更があった場合のみ、変更点を周知するために記載してください。 -->

## 🚀 実装内容
- MeshExtractorのログ対応版関数を作ることで、処理時間などをログに出せるようにしました。
- MeshExtractor各段階の処理時間をログに出すようにしました。
## 🌐 影響範囲
<!-- 既存の実装に対して行った変更や、影響がある部分があれば書いてください(特に同時並行している他の作業に影響する時、今後必要な変更を書く)。また社内の人は、影響先の担当者に対して周知をお願いします。 -->
## 🛠️ 動作確認
unity sdkのfeat/import_timeブランチで処理時間がログで出ているのを確認できます
## ⚠️ 懸念点
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メッシュ抽出操作にロギング機能を追加しました。抽出プロセスの各ステージにおける診断情報とタイミング情報をキャプチャできるようになりました。
  * C APIおよびC#ラッパーに、ログレベルとコールバック機能を指定できる拡張メソッドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->